### PR TITLE
Build Tools: Add a new Grunt task `grunt phpunit:ms-files` for the `ms-files`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -454,6 +454,10 @@ module.exports = function(grunt) {
 				cmd: 'phpunit',
 				args: ['--verbose', '-c', 'tests/phpunit/multisite.xml']
 			},
+			'ms-files': {
+				cmd: 'phpunit',
+				args: ['--verbose', '-c', 'tests/phpunit/multisite.xml', '--group', 'ms-files']
+			},
 			'external-http': {
 				cmd: 'phpunit',
 				args: ['--verbose', '-c', 'phpunit.xml.dist', '--group', 'external-http']


### PR DESCRIPTION
This change adds the multisite `ms-files` group of PHPUnit tests as a new multisite PHPUnit Grunt task for Travis CI jobs.