### PR TITLE
Build Tools: Add a PHPUnit Grunt "watch" task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function(grunt) {
 		BUILD_DIR = 'build/',
  		BANNER_TEXT = '/*! This file is auto-generated */',
 		autoprefixer = require( 'autoprefixer' ),
-		phpUnitWatchFiles = grunt.option( 'files' ) && SOURCE_DIR + grunt.option( 'files' );
+		phpUnitWatchFiles = grunt.option( 'files' ) && SOURCE_DIR + grunt.option( 'files' ),
 		phpUnitWatchGroup = grunt.option( 'group' );
 
 	if ( 'watch:phpunit' === grunt.cli.tasks[ 0 ] ) {
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
 		if ( ! phpUnitWatchFiles || ! phpUnitWatchGroup ) {
 			grunt.log.writeln();
 			grunt.fail.fatal(
-				'Missing required parameters. Example usage: ' + "\n\n" +
+				'Missing required parameters. Example usage: ' + '\n\n' +
 				'grunt watch:phpunit --files=wp-admin/includes --group=community-events'
 			);
 		}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,24 @@ module.exports = function(grunt) {
 		SOURCE_DIR = 'src/',
 		BUILD_DIR = 'build/',
  		BANNER_TEXT = '/*! This file is auto-generated */',
-		autoprefixer = require( 'autoprefixer' );
+		autoprefixer = require( 'autoprefixer' ),
+		phpUnitWatchFiles = grunt.option( 'files' ) && SOURCE_DIR + grunt.option( 'files' );
+		phpUnitWatchGroup = grunt.option( 'group' );
+
+	if ( 'watch:phpunit' === grunt.cli.tasks[ 0 ] ) {
+		if ( phpUnitWatchFiles && '.php' !== phpUnitWatchFiles.substring( phpUnitWatchFiles.length - 4 ) ) {
+			phpUnitWatchFiles += '/**/*.php';
+			phpUnitWatchFiles = phpUnitWatchFiles.replace( '//', '/' );
+		}
+
+		if ( ! phpUnitWatchFiles || ! phpUnitWatchGroup ) {
+			grunt.log.writeln();
+			grunt.fail.fatal(
+				'Missing required parameters. Example usage: ' + "\n\n" +
+				'grunt watch:phpunit --files=wp-admin/includes --group=community-events'
+			);
+		}
+	}
 
 	// Load tasks.
 	require('matchdep').filterDev(['grunt-*', '!grunt-legacy-util']).forEach( grunt.loadNpmTasks );
@@ -742,6 +759,10 @@ module.exports = function(grunt) {
 					'!tests/qunit/editor/**'
 				],
 				tasks: ['qunit']
+			},
+			phpunit: {
+				files: [ phpUnitWatchFiles ],
+				tasks: [ 'phpunit:default' ]
 			}
 		}
 	});
@@ -945,7 +966,7 @@ module.exports = function(grunt) {
 	grunt.registerMultiTask('phpunit', 'Runs PHPUnit tests, including the ajax, external-http, and multisite tests.', function() {
 		grunt.util.spawn({
 			cmd: this.data.cmd,
-			args: this.data.args,
+			args: phpUnitWatchGroup ? this.data.args.concat( [ '--group', phpUnitWatchGroup ] ) : this.data.args,
 			opts: {stdio: 'inherit'}
 		}, this.async());
 	});


### PR DESCRIPTION
This change adds a new Grunt task `grunt phpunit:watch` task that allows you to "watch" a file or files in a folder and run specific PHPUnit "group" tests against and PHP file changes.

See https://core.trac.wordpress.org/ticket/42282