### PR TITLE
Test 43218 with updated Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,11 @@ before_script:
   # Install the specified version of PHPUnit depending on the PHP version:
   if [[ "$WP_TRAVISCI" == "travis:phpunit" ]]; then
     case "$TRAVIS_PHP_VERSION" in
-      7.2|7.1|7.0|nightly)
+      7.2|7.1|nightly)
+        echo "Using PHPUnit 7.x"
+        composer global require "phpunit/phpunit:^7"
+        ;;
+      7.0)
         echo "Using PHPUnit 6.x"
         composer global require "phpunit/phpunit:^6"
         ;;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10103 @@
+{
+	"name": "WordPress",
+	"version": "5.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
+		},
+		"accepts": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+			"integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+			"dev": true,
+			"requires": {
+				"mime-types": "2.1.17",
+				"negotiator": "0.6.1"
+			}
+		},
+		"acorn": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+			"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+			"dev": true
+		},
+		"acorn-dynamic-import": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+			"dev": true,
+			"requires": {
+				"acorn": "4.0.13"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "4.0.13",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+					"dev": true
+				}
+			}
+		},
+		"ajv": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+			"dev": true,
+			"requires": {
+				"co": "4.6.0",
+				"json-stable-stringify": "1.0.1"
+			},
+			"dependencies": {
+				"co": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+					"dev": true
+				}
+			}
+		},
+		"ajv-keywords": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
+		"ansi-escapes": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+			"dev": true
+		},
+		"ansi-html": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"anymatch": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
+			"requires": {
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
+			}
+		},
+		"applause": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/applause/-/applause-1.2.2.tgz",
+			"integrity": "sha1-qEaFeegfZzl7tWNMKZU77c0PVsA=",
+			"dev": true,
+			"requires": {
+				"cson-parser": "1.3.5",
+				"js-yaml": "3.10.0",
+				"lodash": "3.10.1"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "1.0.9",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+					"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "1.0.3"
+					}
+				},
+				"esprima": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+					"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+					"dev": true,
+					"requires": {
+						"argparse": "1.0.9",
+						"esprima": "4.0.0"
+					}
+				},
+				"lodash": {
+					"version": "3.10.1",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+					"dev": true
+				}
+			}
+		},
+		"aproba": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
+		},
+		"archive-type": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
+			"integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
+			"dev": true,
+			"requires": {
+				"file-type": "3.9.0"
+			}
+		},
+		"archiver": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
+			"integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
+			"dev": true,
+			"requires": {
+				"archiver-utils": "1.3.0",
+				"async": "2.5.0",
+				"buffer-crc32": "0.2.13",
+				"glob": "7.1.2",
+				"lodash": "4.17.4",
+				"readable-stream": "2.3.3",
+				"tar-stream": "1.5.4",
+				"walkdir": "0.0.11",
+				"zip-stream": "1.2.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+					"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+					"dev": true,
+					"requires": {
+						"lodash": "4.17.4"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				}
+			}
+		},
+		"archiver-utils": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+			"integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"lazystream": "1.0.0",
+				"lodash": "4.17.4",
+				"normalize-path": "2.1.1",
+				"readable-stream": "2.3.3"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				}
+			}
+		},
+		"are-we-there-yet": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+			"dev": true,
+			"requires": {
+				"delegates": "1.0.0",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"argparse": {
+			"version": "0.1.16",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+			"integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+			"dev": true,
+			"requires": {
+				"underscore": "1.7.0",
+				"underscore.string": "2.4.0"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+					"integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+					"dev": true
+				},
+				"underscore.string": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+					"integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+					"dev": true
+				}
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+			"dev": true
+		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+			"dev": true
+		},
+		"array-flatten": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+			"dev": true
+		},
+		"array-includes": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"dev": true,
+			"requires": {
+				"define-properties": "1.1.2",
+				"es-abstract": "1.9.0"
+			}
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
+			"requires": {
+				"array-uniq": "1.0.3"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
+		},
+		"asn1.js": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"assert": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"dev": true,
+			"requires": {
+				"util": "0.10.3"
+			}
+		},
+		"assert-plus": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+			"dev": true
+		},
+		"async": {
+			"version": "0.1.22",
+			"resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+			"integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+			"dev": true
+		},
+		"async-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true
+		},
+		"async-each-series": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
+			"integrity": "sha1-9C/YFV048hpbjqB8KOBj7RcAsTg=",
+			"dev": true,
+			"optional": true
+		},
+		"async-foreach": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+			"integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"autoprefixer": {
+			"version": "6.7.7",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+			"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+			"dev": true,
+			"requires": {
+				"browserslist": "1.7.7",
+				"caniuse-db": "1.0.30000756",
+				"normalize-range": "0.1.2",
+				"num2fraction": "1.2.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"aws-sign2": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+			"dev": true
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+			"dev": true
+		},
+		"babylon": {
+			"version": "7.0.0-beta.19",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+			"integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"base64-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+			"integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+			"dev": true
+		},
+		"batch": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+			"dev": true
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"beeper": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+			"dev": true
+		},
+		"big.js": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+			"dev": true
+		},
+		"bin-build": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
+			"integrity": "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"archive-type": "3.2.0",
+				"decompress": "3.0.0",
+				"download": "4.4.3",
+				"exec-series": "1.0.3",
+				"rimraf": "2.2.8",
+				"tempfile": "1.1.1",
+				"url-regex": "3.2.0"
+			}
+		},
+		"bin-check": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
+			"integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"executable": "1.1.0"
+			}
+		},
+		"bin-version": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
+			"integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"find-versions": "1.2.1"
+			}
+		},
+		"bin-version-check": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+			"integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"bin-version": "1.0.4",
+				"minimist": "1.2.0",
+				"semver": "4.3.6",
+				"semver-truncate": "1.1.2"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "4.3.6",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+					"integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"bin-wrapper": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
+			"integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"bin-check": "2.0.0",
+				"bin-version-check": "2.1.0",
+				"download": "4.4.3",
+				"each-async": "1.1.1",
+				"lazy-req": "1.1.0",
+				"os-filter-obj": "1.0.3"
+			}
+		},
+		"binary-extensions": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+			"integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+			"dev": true
+		},
+		"bl": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+			"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"block-stream": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3"
+			}
+		},
+		"bluebird": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+			"dev": true
+		},
+		"bn.js": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+			"dev": true
+		},
+		"body-parser": {
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+			"integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
+			"dev": true,
+			"requires": {
+				"bytes": "2.2.0",
+				"content-type": "1.0.4",
+				"debug": "2.2.0",
+				"depd": "1.1.1",
+				"http-errors": "1.3.1",
+				"iconv-lite": "0.4.13",
+				"on-finished": "2.3.0",
+				"qs": "5.2.0",
+				"raw-body": "2.1.7",
+				"type-is": "1.6.15"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.13",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+					"integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+					"dev": true
+				},
+				"qs": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+					"integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
+					"dev": true
+				}
+			}
+		},
+		"bonjour": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+			"dev": true,
+			"requires": {
+				"array-flatten": "2.1.1",
+				"deep-equal": "1.0.1",
+				"dns-equal": "1.0.0",
+				"dns-txt": "2.0.2",
+				"multicast-dns": "6.1.1",
+				"multicast-dns-service-types": "1.1.0"
+			}
+		},
+		"boom": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"dev": true,
+			"requires": {
+				"hoek": "2.16.3"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"dev": true,
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"dev": true
+		},
+		"browserify-aes": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+			"dev": true,
+			"requires": {
+				"buffer-xor": "1.0.3",
+				"cipher-base": "1.0.4",
+				"create-hash": "1.1.3",
+				"evp_bytestokey": "1.0.3",
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"browserify-cipher": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+			"dev": true,
+			"requires": {
+				"browserify-aes": "1.1.1",
+				"browserify-des": "1.0.0",
+				"evp_bytestokey": "1.0.3"
+			}
+		},
+		"browserify-des": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+			"dev": true,
+			"requires": {
+				"cipher-base": "1.0.4",
+				"des.js": "1.0.0",
+				"inherits": "2.0.3"
+			}
+		},
+		"browserify-rsa": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"randombytes": "2.0.5"
+			}
+		},
+		"browserify-sign": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"elliptic": "6.4.0",
+				"inherits": "2.0.3",
+				"parse-asn1": "5.1.0"
+			}
+		},
+		"browserify-zlib": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"dev": true,
+			"requires": {
+				"pako": "0.2.9"
+			}
+		},
+		"browserslist": {
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+			"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+			"dev": true,
+			"requires": {
+				"caniuse-db": "1.0.30000756",
+				"electron-to-chromium": "1.3.27"
+			}
+		},
+		"buffer": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+			"dev": true,
+			"requires": {
+				"base64-js": "1.2.1",
+				"ieee754": "1.1.8",
+				"isarray": "1.0.0"
+			}
+		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+			"dev": true
+		},
+		"buffer-indexof": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+			"dev": true
+		},
+		"buffer-to-vinyl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
+			"integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
+			"dev": true,
+			"requires": {
+				"file-type": "3.9.0",
+				"readable-stream": "2.3.3",
+				"uuid": "2.0.3",
+				"vinyl": "1.2.0"
+			}
+		},
+		"buffer-xor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+			"dev": true
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
+		},
+		"builtin-status-codes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+			"dev": true
+		},
+		"bytes": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+			"integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg=",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+			"dev": true
+		},
+		"camelcase-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+			"dev": true,
+			"requires": {
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
+			}
+		},
+		"caniuse-db": {
+			"version": "1.0.30000756",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000756.tgz",
+			"integrity": "sha1-6TimuZFjDzDSJj3TRYvrZdNiJos=",
+			"dev": true
+		},
+		"capture-stack-trace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+			"dev": true
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
+		},
+		"catharsis": {
+			"version": "0.8.9",
+			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+			"integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+			"dev": true,
+			"requires": {
+				"underscore-contrib": "0.3.0"
+			}
+		},
+		"caw": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
+			"integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
+			"dev": true,
+			"requires": {
+				"get-proxy": "1.1.0",
+				"is-obj": "1.0.1",
+				"object-assign": "3.0.0",
+				"tunnel-agent": "0.4.3"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+					"dev": true
+				}
+			}
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
+		"chokidar": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
+			"requires": {
+				"anymatch": "1.3.2",
+				"async-each": "1.0.1",
+				"fsevents": "1.1.2",
+				"glob-parent": "2.0.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "2.0.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"clap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"chalk": "1.1.3"
+			}
+		},
+		"clean-css": {
+			"version": "3.4.28",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
+			"integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
+			"dev": true,
+			"requires": {
+				"commander": "2.8.1",
+				"source-map": "0.4.4"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"cli": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+			"integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+			"dev": true,
+			"requires": {
+				"exit": "0.1.2",
+				"glob": "7.1.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				}
+			}
+		},
+		"cli-cursor": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "1.0.1"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
+		},
+		"cliui": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"dev": true,
+			"requires": {
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
+				"wordwrap": "0.0.2"
+			}
+		},
+		"clone": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+			"integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+			"dev": true
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+			"dev": true
+		},
+		"co": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+			"integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
+			"dev": true
+		},
+		"coa": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"q": "1.5.1"
+			}
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"coffee-script": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+			"integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+			"dev": true
+		},
+		"color-convert": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"colors": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+			"integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+			"dev": true
+		},
+		"combined-stream": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+			"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+			"dev": true,
+			"requires": {
+				"graceful-readlink": "1.0.1"
+			}
+		},
+		"compress-commons": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+			"integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+			"dev": true,
+			"requires": {
+				"buffer-crc32": "0.2.13",
+				"crc32-stream": "2.0.0",
+				"normalize-path": "2.1.1",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"compressible": {
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
+			"integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
+			"dev": true,
+			"requires": {
+				"mime-db": "1.30.0"
+			}
+		},
+		"compression": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
+			"integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
+			"dev": true,
+			"requires": {
+				"accepts": "1.3.4",
+				"bytes": "3.0.0",
+				"compressible": "2.0.12",
+				"debug": "2.6.9",
+				"on-headers": "1.0.1",
+				"safe-buffer": "5.1.1",
+				"vary": "1.1.2"
+			},
+			"dependencies": {
+				"bytes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+					"dev": true
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"typedarray": "0.0.6"
+			}
+		},
+		"connect-history-api-fallback": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.4.0.tgz",
+			"integrity": "sha1-PbJPlz9LkjsOgvYZzg3wJBHKYj0=",
+			"dev": true
+		},
+		"console-browserify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+			"dev": true,
+			"requires": {
+				"date-now": "0.1.4"
+			}
+		},
+		"console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
+		},
+		"console-stream": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
+			"integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ=",
+			"dev": true,
+			"optional": true
+		},
+		"constants-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+			"dev": true
+		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+			"dev": true
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+			"dev": true
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+			"dev": true
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+			"dev": true
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"crc": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+			"integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
+			"dev": true
+		},
+		"crc32-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+			"integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+			"dev": true,
+			"requires": {
+				"crc": "3.5.0",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"create-ecdh": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"elliptic": "6.4.0"
+			}
+		},
+		"create-error-class": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"dev": true,
+			"requires": {
+				"capture-stack-trace": "1.0.0"
+			}
+		},
+		"create-hash": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+			"dev": true,
+			"requires": {
+				"cipher-base": "1.0.4",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.1",
+				"sha.js": "2.4.9"
+			}
+		},
+		"create-hmac": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+			"dev": true,
+			"requires": {
+				"cipher-base": "1.0.4",
+				"create-hash": "1.1.3",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.1",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.9"
+			}
+		},
+		"cross-spawn": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+			"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+			"dev": true,
+			"requires": {
+				"lru-cache": "4.1.1",
+				"which": "1.3.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
+					}
+				},
+				"which": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+					"dev": true,
+					"requires": {
+						"isexe": "2.0.0"
+					}
+				}
+			}
+		},
+		"cryptiles": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"dev": true,
+			"requires": {
+				"boom": "2.10.1"
+			}
+		},
+		"crypto-browserify": {
+			"version": "3.11.1",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+			"dev": true,
+			"requires": {
+				"browserify-cipher": "1.0.0",
+				"browserify-sign": "4.0.4",
+				"create-ecdh": "4.0.0",
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"diffie-hellman": "5.0.2",
+				"inherits": "2.0.3",
+				"pbkdf2": "3.0.14",
+				"public-encrypt": "4.0.0",
+				"randombytes": "2.0.5"
+			}
+		},
+		"cson-parser": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
+			"integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
+			"dev": true,
+			"requires": {
+				"coffee-script": "1.12.7"
+			},
+			"dependencies": {
+				"coffee-script": {
+					"version": "1.12.7",
+					"resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+					"integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+					"dev": true
+				}
+			}
+		},
+		"csso": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-2.0.0.tgz",
+			"integrity": "sha1-F4tDpEYhIhwndWCG9THgL0KQDug=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"clap": "1.2.3",
+				"source-map": "0.5.7"
+			}
+		},
+		"currently-unhandled": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"dev": true,
+			"requires": {
+				"array-find-index": "1.0.2"
+			}
+		},
+		"d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"dev": true,
+			"requires": {
+				"es5-ext": "0.10.35"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"date-now": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+			"dev": true
+		},
+		"dateformat": {
+			"version": "1.0.2-1.2.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+			"integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+			"dev": true
+		},
+		"debug": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+			"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+			"dev": true,
+			"requires": {
+				"ms": "0.7.1"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
+		},
+		"decompress": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
+			"integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
+			"dev": true,
+			"requires": {
+				"buffer-to-vinyl": "1.1.0",
+				"concat-stream": "1.6.0",
+				"decompress-tar": "3.1.0",
+				"decompress-tarbz2": "3.1.0",
+				"decompress-targz": "3.1.0",
+				"decompress-unzip": "3.4.0",
+				"stream-combiner2": "1.1.1",
+				"vinyl-assign": "1.2.1",
+				"vinyl-fs": "2.4.4"
+			}
+		},
+		"decompress-tar": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+			"integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
+			"dev": true,
+			"requires": {
+				"is-tar": "1.0.0",
+				"object-assign": "2.1.1",
+				"strip-dirs": "1.1.1",
+				"tar-stream": "1.5.4",
+				"through2": "0.6.5",
+				"vinyl": "0.4.6"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+					"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+					"dev": true
+				},
+				"object-assign": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+					"dev": true
+				},
+				"vinyl": {
+					"version": "0.4.6",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+					"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+					"dev": true,
+					"requires": {
+						"clone": "0.2.0",
+						"clone-stats": "0.0.1"
+					}
+				}
+			}
+		},
+		"decompress-tarbz2": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+			"integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
+			"dev": true,
+			"requires": {
+				"is-bzip2": "1.0.0",
+				"object-assign": "2.1.1",
+				"seek-bzip": "1.0.5",
+				"strip-dirs": "1.1.1",
+				"tar-stream": "1.5.4",
+				"through2": "0.6.5",
+				"vinyl": "0.4.6"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+					"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+					"dev": true
+				},
+				"object-assign": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+					"dev": true
+				},
+				"vinyl": {
+					"version": "0.4.6",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+					"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+					"dev": true,
+					"requires": {
+						"clone": "0.2.0",
+						"clone-stats": "0.0.1"
+					}
+				}
+			}
+		},
+		"decompress-targz": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+			"integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
+			"dev": true,
+			"requires": {
+				"is-gzip": "1.0.0",
+				"object-assign": "2.1.1",
+				"strip-dirs": "1.1.1",
+				"tar-stream": "1.5.4",
+				"through2": "0.6.5",
+				"vinyl": "0.4.6"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+					"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+					"dev": true
+				},
+				"object-assign": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+					"dev": true
+				},
+				"vinyl": {
+					"version": "0.4.6",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+					"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+					"dev": true,
+					"requires": {
+						"clone": "0.2.0",
+						"clone-stats": "0.0.1"
+					}
+				}
+			}
+		},
+		"decompress-unzip": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
+			"integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
+			"dev": true,
+			"requires": {
+				"is-zip": "1.0.0",
+				"read-all-stream": "3.1.0",
+				"stat-mode": "0.2.2",
+				"strip-dirs": "1.1.1",
+				"through2": "2.0.3",
+				"vinyl": "1.2.0",
+				"yauzl": "2.9.1"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"deep-equal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+			"dev": true
+		},
+		"deep-extend": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+			"dev": true
+		},
+		"deep-for-each": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/deep-for-each/-/deep-for-each-1.0.6.tgz",
+			"integrity": "sha1-r6DOJJxYSSqXIFOUeKGNN+GxC64=",
+			"dev": true,
+			"requires": {
+				"is-plain-object": "2.0.4"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
+			"requires": {
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
+			}
+		},
+		"del": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+			"dev": true,
+			"requires": {
+				"globby": "6.1.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.0",
+				"p-map": "1.2.0",
+				"pify": "3.0.0",
+				"rimraf": "2.2.8"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
+		},
+		"delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+			"dev": true
+		},
+		"depd": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+			"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+			"dev": true
+		},
+		"des.js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+			"dev": true
+		},
+		"detect-node": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
+			"dev": true
+		},
+		"diff": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+			"integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
+			"dev": true
+		},
+		"diffie-hellman": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"miller-rabin": "4.0.1",
+				"randombytes": "2.0.5"
+			}
+		},
+		"dns-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+			"dev": true
+		},
+		"dns-packet": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz",
+			"integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
+			"dev": true,
+			"requires": {
+				"ip": "1.1.5",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"dns-txt": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+			"dev": true,
+			"requires": {
+				"buffer-indexof": "1.1.1"
+			}
+		},
+		"dom-serializer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"dev": true,
+			"requires": {
+				"domelementtype": "1.1.3",
+				"entities": "1.1.1"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+					"dev": true
+				},
+				"entities": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+					"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+					"dev": true
+				}
+			}
+		},
+		"domain-browser": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+			"integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+			"dev": true
+		},
+		"domelementtype": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+			"dev": true
+		},
+		"domhandler": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+			"integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+			"dev": true,
+			"requires": {
+				"domelementtype": "1.3.0"
+			}
+		},
+		"domutils": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"dev": true,
+			"requires": {
+				"dom-serializer": "0.1.0",
+				"domelementtype": "1.3.0"
+			}
+		},
+		"download": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
+			"integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
+			"dev": true,
+			"requires": {
+				"caw": "1.2.0",
+				"concat-stream": "1.6.0",
+				"each-async": "1.1.1",
+				"filenamify": "1.2.1",
+				"got": "5.7.1",
+				"gulp-decompress": "1.2.0",
+				"gulp-rename": "1.2.2",
+				"is-url": "1.2.2",
+				"object-assign": "4.1.1",
+				"read-all-stream": "3.1.0",
+				"readable-stream": "2.3.3",
+				"stream-combiner2": "1.1.1",
+				"vinyl": "1.2.0",
+				"vinyl-fs": "2.4.4",
+				"ware": "1.3.0"
+			}
+		},
+		"duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"duplexify": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+			"integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "1.4.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"each-async": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+			"integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
+			"dev": true,
+			"requires": {
+				"onetime": "1.1.0",
+				"set-immediate-shim": "1.0.1"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+			"dev": true
+		},
+		"electron-to-chromium": {
+			"version": "1.3.27",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
+			"integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
+			"dev": true
+		},
+		"elliptic": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0",
+				"hash.js": "1.1.3",
+				"hmac-drbg": "1.0.1",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
+			}
+		},
+		"emojis-list": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"dev": true
+		},
+		"encodeurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+			"integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+			"dev": true
+		},
+		"end-of-stream": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+			"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"enhanced-resolve": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"memory-fs": "0.4.1",
+				"object-assign": "4.1.1",
+				"tapable": "0.2.8"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				}
+			}
+		},
+		"entities": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+			"integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+			"dev": true
+		},
+		"errno": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+			"dev": true,
+			"requires": {
+				"prr": "0.0.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+			"integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
+			"requires": {
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
+			}
+		},
+		"es5-ext": {
+			"version": "0.10.35",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+			"integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+			"dev": true,
+			"requires": {
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.35",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-map": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.35",
+				"es6-iterator": "2.0.3",
+				"es6-set": "0.1.5",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-promise": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
+			"integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
+			"dev": true
+		},
+		"es6-set": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.35",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.35"
+			}
+		},
+		"es6-weak-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.35",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"escope": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+			"dev": true,
+			"requires": {
+				"es6-map": "0.1.5",
+				"es6-weak-map": "2.0.2",
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"esprima": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+			"integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+			"dev": true
+		},
+		"esrecurse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+			"dev": true
+		},
+		"event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.35"
+			}
+		},
+		"eventemitter2": {
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+			"integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+			"dev": true
+		},
+		"eventemitter3": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+			"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+			"dev": true
+		},
+		"events": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+			"dev": true
+		},
+		"eventsource": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+			"dev": true,
+			"requires": {
+				"original": "1.0.0"
+			}
+		},
+		"evp_bytestokey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"dev": true,
+			"requires": {
+				"md5.js": "1.3.4",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"exec-buffer": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-2.0.1.tgz",
+			"integrity": "sha1-ACijG+CxRgth0HX5avRYO54zXqA=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"rimraf": "2.2.8",
+				"tempfile": "1.1.1"
+			}
+		},
+		"exec-series": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz",
+			"integrity": "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"async-each-series": "1.1.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "4.1.1",
+						"shebang-command": "1.2.0",
+						"which": "1.3.0"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
+					}
+				},
+				"which": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+					"dev": true,
+					"requires": {
+						"isexe": "2.0.0"
+					}
+				}
+			}
+		},
+		"executable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
+			"integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"meow": "3.7.0"
+			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
+		},
+		"exit-hook": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+			"dev": true
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"express": {
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+			"integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+			"dev": true,
+			"requires": {
+				"accepts": "1.3.4",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.2",
+				"content-disposition": "0.5.2",
+				"content-type": "1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "1.1.1",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"finalhandler": "1.1.0",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "2.0.2",
+				"qs": "6.5.1",
+				"range-parser": "1.2.0",
+				"safe-buffer": "5.1.1",
+				"send": "0.16.1",
+				"serve-static": "1.13.1",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.3.1",
+				"type-is": "1.6.15",
+				"utils-merge": "1.0.1",
+				"vary": "1.1.2"
+			},
+			"dependencies": {
+				"array-flatten": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+					"dev": true
+				},
+				"body-parser": {
+					"version": "1.18.2",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+					"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+					"dev": true,
+					"requires": {
+						"bytes": "3.0.0",
+						"content-type": "1.0.4",
+						"debug": "2.6.9",
+						"depd": "1.1.1",
+						"http-errors": "1.6.2",
+						"iconv-lite": "0.4.19",
+						"on-finished": "2.3.0",
+						"qs": "6.5.1",
+						"raw-body": "2.3.2",
+						"type-is": "1.6.15"
+					}
+				},
+				"bytes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+					"dev": true
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"http-errors": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+					"dev": true,
+					"requires": {
+						"depd": "1.1.1",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.0.3",
+						"statuses": "1.3.1"
+					},
+					"dependencies": {
+						"setprototypeof": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+							"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+							"dev": true
+						}
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+					"dev": true
+				},
+				"raw-body": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+					"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+					"dev": true,
+					"requires": {
+						"bytes": "3.0.0",
+						"http-errors": "1.6.2",
+						"iconv-lite": "0.4.19",
+						"unpipe": "1.0.0"
+					}
+				},
+				"statuses": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+					"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+					"dev": true
+				}
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
+		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"requires": {
+				"is-extendable": "0.1.1"
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "1.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				}
+			}
+		},
+		"extract-zip": {
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
+			"integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
+			"dev": true,
+			"requires": {
+				"concat-stream": "1.6.0",
+				"debug": "2.2.0",
+				"mkdirp": "0.5.0",
+				"yauzl": "2.4.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+					"integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"yauzl": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+					"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+					"dev": true,
+					"requires": {
+						"fd-slicer": "1.0.1"
+					}
+				}
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
+		"fancy-log": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+			"integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"time-stamp": "1.1.0"
+			}
+		},
+		"fast-deep-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"faye-websocket": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+			"dev": true,
+			"requires": {
+				"websocket-driver": "0.7.0"
+			}
+		},
+		"fd-slicer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+			"dev": true,
+			"requires": {
+				"pend": "1.2.0"
+			}
+		},
+		"figures": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "1.0.5",
+				"object-assign": "4.1.1"
+			}
+		},
+		"file-sync-cmp": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+			"integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
+			"dev": true
+		},
+		"file-type": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+			"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+			"dev": true
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
+		},
+		"filename-reserved-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
+			"integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+			"dev": true
+		},
+		"filenamify": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
+			"integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+			"dev": true,
+			"requires": {
+				"filename-reserved-regex": "1.0.0",
+				"strip-outer": "1.0.0",
+				"trim-repeated": "1.0.0"
+			}
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"finalhandler": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+			"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"statuses": "1.3.1",
+				"unpipe": "1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"statuses": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+					"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+					"dev": true
+				}
+			}
+		},
+		"find-up": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"dev": true,
+			"requires": {
+				"path-exists": "2.1.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"find-versions": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
+			"integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"array-uniq": "1.0.3",
+				"get-stdin": "4.0.1",
+				"meow": "3.7.0",
+				"semver-regex": "1.0.0"
+			}
+		},
+		"findup": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+			"integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
+			"dev": true,
+			"requires": {
+				"colors": "0.6.2",
+				"commander": "2.1.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+					"integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
+					"dev": true
+				}
+			}
+		},
+		"findup-sync": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+			"integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+			"dev": true,
+			"requires": {
+				"glob": "3.2.11",
+				"lodash": "2.4.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "3.2.11",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.3",
+						"minimatch": "0.3.0"
+					}
+				},
+				"lodash": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "2.7.3",
+						"sigmund": "1.0.1"
+					}
+				}
+			}
+		},
+		"first-chunk-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+			"dev": true
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
+		},
+		"form-data": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"dev": true,
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.5",
+				"mime-types": "2.1.17"
+			}
+		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+			"dev": true
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+			"dev": true
+		},
+		"fs-extra": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+			"integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"jsonfile": "2.4.0",
+				"klaw": "1.3.1"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				}
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"fsevents": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"nan": "2.7.0",
+				"node-pre-gyp": "0.6.36"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+					"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+					"dev": true,
+					"optional": true
+				},
+				"ajv": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"aproba": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+					"integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+					"dev": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
+					}
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+					"dev": true,
+					"optional": true
+				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+					"dev": true,
+					"optional": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+					"dev": true,
+					"optional": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+					"dev": true,
+					"optional": true
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+					"dev": true,
+					"optional": true
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+					"dev": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"block-stream": {
+					"version": "0.0.9",
+					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"boom": {
+					"version": "2.10.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+					"dev": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+					"dev": true,
+					"requires": {
+						"balanced-match": "0.4.2",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-shims": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+					"dev": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+					"dev": true,
+					"optional": true
+				},
+				"co": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+					"dev": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+					"dev": true
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+					"dev": true,
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"dev": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+					"dev": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+					"dev": true
+				},
+				"cryptiles": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"boom": "2.10.1"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+					"dev": true,
+					"optional": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+					"dev": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+					"dev": true,
+					"optional": true
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+					"dev": true,
+					"optional": true
+				},
+				"extsprintf": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+					"dev": true
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+					"dev": true,
+					"optional": true
+				},
+				"form-data": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"dev": true
+				},
+				"fstream": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
+					}
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				},
+				"har-schema": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+					"dev": true,
+					"optional": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+					"dev": true,
+					"optional": true
+				},
+				"hawk": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
+					}
+				},
+				"hoek": {
+					"version": "2.16.3",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+					"dev": true
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"dev": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				},
+				"ini": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+					"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+					"dev": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+					"dev": true,
+					"optional": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+					"dev": true,
+					"optional": true
+				},
+				"jodid25519": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+					"dev": true,
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+					"dev": true,
+					"optional": true
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+					"dev": true,
+					"optional": true
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+					"dev": true,
+					"optional": true
+				},
+				"jsprim": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+					"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.0.2",
+						"json-schema": "0.2.3",
+						"verror": "1.3.6"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"mime-db": {
+					"version": "1.27.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+					"dev": true
+				},
+				"mime-types": {
+					"version": "2.1.15",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+					"dev": true,
+					"requires": {
+						"mime-db": "1.27.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true,
+					"optional": true
+				},
+				"node-pre-gyp": {
+					"version": "0.6.36",
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+					"integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+					"dev": true
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+					"dev": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"dev": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"dev": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"dev": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+					"dev": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"dev": true
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+					"dev": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+					"dev": true
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true,
+					"optional": true
+				},
+				"qs": {
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+					"dev": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.2.9",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+					"dev": true,
+					"requires": {
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.81.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+					"dev": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"dev": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"dev": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"dev": true,
+					"optional": true
+				},
+				"sntp": {
+					"version": "1.0.9",
+					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"sshpk": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+					"dev": true,
+					"optional": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"dev": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+					"dev": true,
+					"requires": {
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
+					}
+				},
+				"tar-pack": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+					"dev": true,
+					"optional": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+					"dev": true,
+					"optional": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+					"dev": true
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+					"dev": true,
+					"optional": true
+				},
+				"verror": {
+					"version": "1.3.6",
+					"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"extsprintf": "1.0.2"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"dev": true
+				}
+			}
+		},
+		"fstream": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"inherits": "2.0.3",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.2.8"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				}
+			}
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"gauge": {
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
+			"requires": {
+				"aproba": "1.2.0",
+				"console-control-strings": "1.1.0",
+				"has-unicode": "2.0.1",
+				"object-assign": "4.1.1",
+				"signal-exit": "3.0.2",
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wide-align": "1.1.2"
+			}
+		},
+		"gaze": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+			"integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+			"dev": true,
+			"requires": {
+				"globule": "1.2.0"
+			}
+		},
+		"generate-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
+		},
+		"generate-object-property": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"dev": true,
+			"requires": {
+				"is-property": "1.0.2"
+			}
+		},
+		"get-caller-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+			"dev": true
+		},
+		"get-proxy": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
+			"integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
+			"dev": true,
+			"requires": {
+				"rc": "1.2.2"
+			}
+		},
+		"get-stdin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+			"dev": true
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+			"dev": true
+		},
+		"getobject": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+			"integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+			"dev": true
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"gifsicle": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/gifsicle/-/gifsicle-3.0.4.tgz",
+			"integrity": "sha1-9Fy17RAWW2ZdySng6TKLbIId+js=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"bin-build": "2.2.0",
+				"bin-wrapper": "3.0.2",
+				"logalot": "2.1.0"
+			}
+		},
+		"glob": {
+			"version": "3.1.21",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+			"integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "1.2.3",
+				"inherits": "1.0.2",
+				"minimatch": "0.2.14"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+					"integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+					"dev": true
+				}
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"dev": true,
+			"requires": {
+				"is-glob": "3.1.0",
+				"path-dirname": "1.0.2"
+			}
+		},
+		"glob-stream": {
+			"version": "5.3.5",
+			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+			"dev": true,
+			"requires": {
+				"extend": "3.0.1",
+				"glob": "5.0.15",
+				"glob-parent": "3.1.0",
+				"micromatch": "2.3.11",
+				"ordered-read-streams": "0.3.0",
+				"through2": "0.6.5",
+				"to-absolute-glob": "0.1.1",
+				"unique-stream": "2.2.1"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				}
+			}
+		},
+		"globby": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+			"dev": true,
+			"requires": {
+				"array-union": "1.0.2",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				}
+			}
+		},
+		"globule": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+			"integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				}
+			}
+		},
+		"glogg": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+			"integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+			"dev": true,
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"got": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+			"integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+			"dev": true,
+			"requires": {
+				"create-error-class": "3.0.2",
+				"duplexer2": "0.1.4",
+				"is-redirect": "1.0.0",
+				"is-retry-allowed": "1.1.0",
+				"is-stream": "1.1.0",
+				"lowercase-keys": "1.0.0",
+				"node-status-codes": "1.0.0",
+				"object-assign": "4.1.1",
+				"parse-json": "2.2.0",
+				"pinkie-promise": "2.0.1",
+				"read-all-stream": "3.1.0",
+				"readable-stream": "2.3.3",
+				"timed-out": "3.1.3",
+				"unzip-response": "1.0.2",
+				"url-parse-lax": "1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+			"integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+			"dev": true
+		},
+		"graceful-readlink": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+			"dev": true
+		},
+		"grunt": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+			"integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+			"dev": true,
+			"requires": {
+				"async": "0.1.22",
+				"coffee-script": "1.3.3",
+				"colors": "0.6.2",
+				"dateformat": "1.0.2-1.2.3",
+				"eventemitter2": "0.4.14",
+				"exit": "0.1.2",
+				"findup-sync": "0.1.3",
+				"getobject": "0.1.0",
+				"glob": "3.1.21",
+				"grunt-legacy-log": "0.1.3",
+				"grunt-legacy-util": "0.2.0",
+				"hooker": "0.2.3",
+				"iconv-lite": "0.2.11",
+				"js-yaml": "2.0.5",
+				"lodash": "0.9.2",
+				"minimatch": "0.2.14",
+				"nopt": "1.0.10",
+				"rimraf": "2.2.8",
+				"underscore.string": "2.2.1",
+				"which": "1.0.9"
+			}
+		},
+		"grunt-banner": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/grunt-banner/-/grunt-banner-0.6.0.tgz",
+			"integrity": "sha1-P4eQIdEj+linuloLb7a+QStYhaw=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3"
+			}
+		},
+		"grunt-contrib-clean": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.0.0.tgz",
+			"integrity": "sha1-ay7ZQRfix//jLuBFeMlv5GJam20=",
+			"dev": true,
+			"requires": {
+				"async": "1.5.2",
+				"rimraf": "2.6.2"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+					"dev": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				}
+			}
+		},
+		"grunt-contrib-compress": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.3.0.tgz",
+			"integrity": "sha1-XlwmogBJCCPH93KIr9LXNQ2Vxj0=",
+			"dev": true,
+			"requires": {
+				"archiver": "1.3.0",
+				"chalk": "1.1.3",
+				"lodash": "4.17.4",
+				"pretty-bytes": "3.0.1",
+				"stream-buffers": "2.2.0"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				}
+			}
+		},
+		"grunt-contrib-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
+			"integrity": "sha1-YVCYYwhOhx1+ht5IwBUlntl3Rb0=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"source-map": "0.5.7"
+			}
+		},
+		"grunt-contrib-copy": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
+			"integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"file-sync-cmp": "0.1.1"
+			}
+		},
+		"grunt-contrib-cssmin": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-1.0.2.tgz",
+			"integrity": "sha1-FzTL09hMpzZHWLflj/GOUqpgu3Y=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"clean-css": "3.4.28",
+				"maxmin": "1.1.0"
+			}
+		},
+		"grunt-contrib-imagemin": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-imagemin/-/grunt-contrib-imagemin-1.0.1.tgz",
+			"integrity": "sha1-5Ho1YTN29MqpwfkERlA8rhyUTXk=",
+			"dev": true,
+			"requires": {
+				"async": "1.5.2",
+				"chalk": "1.1.3",
+				"gulp-rename": "1.2.2",
+				"imagemin": "4.0.0",
+				"pretty-bytes": "3.0.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				}
+			}
+		},
+		"grunt-contrib-jshint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.0.0.tgz",
+			"integrity": "sha1-MPQFpR3mVr+m6wKbmkZLn+AqQCo=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"hooker": "0.2.3",
+				"jshint": "2.9.5"
+			}
+		},
+		"grunt-contrib-qunit": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-qunit/-/grunt-contrib-qunit-1.3.0.tgz",
+			"integrity": "sha1-naxijP1OyBWZhjPbc7Ur2z3byZ4=",
+			"dev": true,
+			"requires": {
+				"grunt-lib-phantomjs": "1.1.0"
+			}
+		},
+		"grunt-contrib-uglify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-2.0.0.tgz",
+			"integrity": "sha1-jJlw1pCTbN5tJaoRk1Sb2SkBaTA=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"lodash.assign": "4.2.0",
+				"maxmin": "1.1.0",
+				"uglify-js": "2.7.5",
+				"uri-path": "1.0.0"
+			}
+		},
+		"grunt-contrib-watch": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz",
+			"integrity": "sha1-hKGnodar0m7VaEE0lscxM+mQAY8=",
+			"dev": true,
+			"requires": {
+				"async": "1.5.2",
+				"gaze": "1.1.2",
+				"lodash": "3.10.1",
+				"tiny-lr": "0.2.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
+				"lodash": {
+					"version": "3.10.1",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+					"dev": true
+				}
+			}
+		},
+		"grunt-includes": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/grunt-includes/-/grunt-includes-0.5.4.tgz",
+			"integrity": "sha1-fGyS4LM3rOYjMYHZ+NMWodSY4yk=",
+			"dev": true
+		},
+		"grunt-jsdoc": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/grunt-jsdoc/-/grunt-jsdoc-2.2.0.tgz",
+			"integrity": "sha512-3/HzvzcG7gxlm4YefR5ELbsUB/bIFCeX3CbUeAANKGMfNUZ2tDQ+Pp0YRb/VWHjyu+v8wG6n1PD8yIjubjEDeg==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "3.0.1",
+				"jsdoc": "3.5.5"
+			}
+		},
+		"grunt-jsvalidate": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/grunt-jsvalidate/-/grunt-jsvalidate-0.2.2.tgz",
+			"integrity": "sha1-/QlEJYiNbmPfqgbPsJ7gUrjrvo8=",
+			"dev": true,
+			"requires": {
+				"esprima": "1.0.4"
+			}
+		},
+		"grunt-legacy-log": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+			"integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+			"dev": true,
+			"requires": {
+				"colors": "0.6.2",
+				"grunt-legacy-log-utils": "0.1.1",
+				"hooker": "0.2.3",
+				"lodash": "2.4.2",
+				"underscore.string": "2.3.3"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+					"dev": true
+				},
+				"underscore.string": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+					"integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+					"dev": true
+				}
+			}
+		},
+		"grunt-legacy-log-utils": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+			"integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+			"dev": true,
+			"requires": {
+				"colors": "0.6.2",
+				"lodash": "2.4.2",
+				"underscore.string": "2.3.3"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+					"dev": true
+				},
+				"underscore.string": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+					"integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+					"dev": true
+				}
+			}
+		},
+		"grunt-legacy-util": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+			"integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+			"dev": true,
+			"requires": {
+				"async": "0.1.22",
+				"exit": "0.1.2",
+				"getobject": "0.1.0",
+				"hooker": "0.2.3",
+				"lodash": "0.9.2",
+				"underscore.string": "2.2.1",
+				"which": "1.0.9"
+			}
+		},
+		"grunt-lib-phantomjs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/grunt-lib-phantomjs/-/grunt-lib-phantomjs-1.1.0.tgz",
+			"integrity": "sha1-np7c3Z/S3UDgwYHJQ3HVcqpe6tI=",
+			"dev": true,
+			"requires": {
+				"eventemitter2": "0.4.14",
+				"phantomjs-prebuilt": "2.1.15",
+				"rimraf": "2.6.2",
+				"semver": "5.4.1",
+				"temporary": "0.0.8"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+					"dev": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				}
+			}
+		},
+		"grunt-patch-wordpress": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/grunt-patch-wordpress/-/grunt-patch-wordpress-0.4.2.tgz",
+			"integrity": "sha1-wO38taMmPpk8wWk98RsrPkSG2Mg=",
+			"dev": true,
+			"requires": {
+				"inquirer": "0.12.0",
+				"request": "2.69.0",
+				"underscore": "1.8.3",
+				"underscore.string": "3.3.4",
+				"xmlrpc": "1.3.2"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+					"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+					"dev": true,
+					"requires": {
+						"lodash": "4.17.4"
+					}
+				},
+				"bl": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+					"integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2.0.6"
+					}
+				},
+				"caseless": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+					"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+					"dev": true
+				},
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"dev": true
+				},
+				"form-data": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+					"integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+					"dev": true,
+					"requires": {
+						"async": "2.5.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.17"
+					}
+				},
+				"har-validator": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+					"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+					"dev": true,
+					"requires": {
+						"chalk": "1.1.3",
+						"commander": "2.11.0",
+						"is-my-json-valid": "2.16.1",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.0.4",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.0.4.tgz",
+					"integrity": "sha1-UQGdhHIMk5uCc36EVWp4Izjs6ns=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "0.10.31",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.69.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
+					"integrity": "sha1-z5HS4AB1KxIXFVwAUkGRGZGiNGo=",
+					"dev": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"bl": "1.0.3",
+						"caseless": "0.11.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "1.0.1",
+						"har-validator": "2.0.6",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.17",
+						"node-uuid": "1.4.8",
+						"oauth-sign": "0.8.2",
+						"qs": "6.0.4",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.2.2",
+						"tunnel-agent": "0.4.3"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
+					"integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc=",
+					"dev": true
+				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+					"dev": true
+				},
+				"underscore.string": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+					"integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				}
+			}
+		},
+		"grunt-postcss": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/grunt-postcss/-/grunt-postcss-0.7.2.tgz",
+			"integrity": "sha1-V7dke4d9Qq0yz51M0RAID/+0OKs=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"diff": "2.2.3",
+				"es6-promise": "3.3.1",
+				"postcss": "5.2.18"
+			},
+			"dependencies": {
+				"es6-promise": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+					"integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+					"dev": true
+				}
+			}
+		},
+		"grunt-replace": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/grunt-replace/-/grunt-replace-1.0.1.tgz",
+			"integrity": "sha1-kKeVMvuJBB/kJ8h9QlI4sPiGZRo=",
+			"dev": true,
+			"requires": {
+				"applause": "1.2.2",
+				"chalk": "1.1.3",
+				"file-sync-cmp": "0.1.1",
+				"lodash": "4.17.4"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				}
+			}
+		},
+		"grunt-rtlcss": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/grunt-rtlcss/-/grunt-rtlcss-2.0.1.tgz",
+			"integrity": "sha1-6eYc5DdAY5f546Sxv2aeR+cf/MM=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"rtlcss": "2.2.0"
+			}
+		},
+		"grunt-sass": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-2.0.0.tgz",
+			"integrity": "sha1-kHTPnXtFkuIPd4jKpye4+aoGtgo=",
+			"dev": true,
+			"requires": {
+				"each-async": "1.1.1",
+				"node-sass": "4.7.2",
+				"object-assign": "4.1.1"
+			}
+		},
+		"grunt-webpack": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/grunt-webpack/-/grunt-webpack-3.0.2.tgz",
+			"integrity": "sha512-ghSkdCdvbF1SpI46qDT9FYqw5ZP5sSYbEQU/DwzoJE1K42xizAZ5Rv3kzpaRdJT4yvu8/6fO5+wne3/y0n74QA==",
+			"dev": true,
+			"requires": {
+				"deep-for-each": "1.0.6",
+				"lodash": "4.17.4"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				}
+			}
+		},
+		"gulp-decompress": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
+			"integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
+			"dev": true,
+			"requires": {
+				"archive-type": "3.2.0",
+				"decompress": "3.0.0",
+				"gulp-util": "3.0.8",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"gulp-rename": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+			"integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc=",
+			"dev": true
+		},
+		"gulp-sourcemaps": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+			"dev": true,
+			"requires": {
+				"convert-source-map": "1.5.0",
+				"graceful-fs": "4.1.11",
+				"strip-bom": "2.0.0",
+				"through2": "2.0.3",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				},
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"gulp-util": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+			"dev": true,
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-uniq": "1.0.3",
+				"beeper": "1.1.1",
+				"chalk": "1.1.3",
+				"dateformat": "2.2.0",
+				"fancy-log": "1.3.0",
+				"gulplog": "1.0.0",
+				"has-gulplog": "0.1.0",
+				"lodash._reescape": "3.0.0",
+				"lodash._reevaluate": "3.0.0",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.template": "3.6.2",
+				"minimist": "1.2.0",
+				"multipipe": "0.1.2",
+				"object-assign": "3.0.0",
+				"replace-ext": "0.0.1",
+				"through2": "2.0.3",
+				"vinyl": "0.5.3"
+			},
+			"dependencies": {
+				"dateformat": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+					"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+					"dev": true
+				},
+				"object-assign": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+					"dev": true
+				},
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				},
+				"vinyl": {
+					"version": "0.5.3",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+					"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.2",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulplog": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+			"dev": true,
+			"requires": {
+				"glogg": "1.0.0"
+			}
+		},
+		"gzip-size": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
+			"integrity": "sha1-Zs+LEBBHInuVus5uodoMF37Vwi8=",
+			"dev": true,
+			"requires": {
+				"browserify-zlib": "0.1.4",
+				"concat-stream": "1.6.0"
+			}
+		},
+		"handle-thing": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
+			"dev": true
+		},
+		"har-schema": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+			"dev": true
+		},
+		"har-validator": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+			"dev": true,
+			"requires": {
+				"ajv": "4.11.8",
+				"har-schema": "1.0.5"
+			}
+		},
+		"has": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
+			"requires": {
+				"function-bind": "1.1.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+			"dev": true
+		},
+		"has-gulplog": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+			"dev": true,
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+			"dev": true
+		},
+		"hash-base": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3"
+			}
+		},
+		"hash.js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"hasha": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+			"integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+			"dev": true,
+			"requires": {
+				"is-stream": "1.1.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"hawk": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"dev": true,
+			"requires": {
+				"boom": "2.10.1",
+				"cryptiles": "2.0.5",
+				"hoek": "2.16.3",
+				"sntp": "1.0.9"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"dev": true,
+			"requires": {
+				"hash.js": "1.1.3",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
+			}
+		},
+		"hoek": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+			"dev": true
+		},
+		"hooker": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+			"integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+			"dev": true
+		},
+		"hosted-git-info": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+			"dev": true
+		},
+		"hpack.js": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"obuf": "1.1.1",
+				"readable-stream": "2.3.3",
+				"wbuf": "1.7.2"
+			}
+		},
+		"html-entities": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+			"dev": true
+		},
+		"htmlparser2": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+			"integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+			"dev": true,
+			"requires": {
+				"domelementtype": "1.3.0",
+				"domhandler": "2.3.0",
+				"domutils": "1.5.1",
+				"entities": "1.0.0",
+				"readable-stream": "1.1.14"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
+		},
+		"http-deceiver": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+			"dev": true
+		},
+		"http-errors": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+			"integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"statuses": "1.4.0"
+			}
+		},
+		"http-parser-js": {
+			"version": "0.4.9",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
+			"integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
+			"dev": true
+		},
+		"http-proxy": {
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+			"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+			"dev": true,
+			"requires": {
+				"eventemitter3": "1.2.0",
+				"requires-port": "1.0.0"
+			}
+		},
+		"http-proxy-middleware": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+			"dev": true,
+			"requires": {
+				"http-proxy": "1.16.2",
+				"is-glob": "3.1.0",
+				"lodash": "4.17.4",
+				"micromatch": "2.3.11"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				}
+			}
+		},
+		"http-signature": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "0.2.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"https-browserify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+			"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+			"dev": true
+		},
+		"iconv-lite": {
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+			"integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+			"dev": true
+		},
+		"ieee754": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+			"dev": true
+		},
+		"imagemin": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/imagemin/-/imagemin-4.0.0.tgz",
+			"integrity": "sha1-6Q5/CTaDZZXxj6Ff6Qb0+iWeqEc=",
+			"dev": true,
+			"requires": {
+				"buffer-to-vinyl": "1.1.0",
+				"concat-stream": "1.6.0",
+				"imagemin-gifsicle": "4.2.0",
+				"imagemin-jpegtran": "4.3.2",
+				"imagemin-optipng": "4.3.0",
+				"imagemin-svgo": "4.2.1",
+				"optional": "0.1.4",
+				"readable-stream": "2.3.3",
+				"stream-combiner2": "1.1.1",
+				"vinyl-fs": "2.4.4"
+			}
+		},
+		"imagemin-gifsicle": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-4.2.0.tgz",
+			"integrity": "sha1-D++butNHbmt2iFc2zFsLh6CHV8o=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"gifsicle": "3.0.4",
+				"is-gif": "1.0.0",
+				"through2": "0.6.5"
+			}
+		},
+		"imagemin-jpegtran": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/imagemin-jpegtran/-/imagemin-jpegtran-4.3.2.tgz",
+			"integrity": "sha1-G8bR4r0T/bZNJFUm1jWn5d/rEvw=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-jpg": "1.0.0",
+				"jpegtran-bin": "3.2.0",
+				"through2": "2.0.3"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"imagemin-optipng": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-4.3.0.tgz",
+			"integrity": "sha1-dgRmOrLuMVczJ0cm/Rw3TStErbY=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"exec-buffer": "2.0.1",
+				"is-png": "1.1.0",
+				"optipng-bin": "3.1.4",
+				"through2": "0.6.5"
+			}
+		},
+		"imagemin-svgo": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-4.2.1.tgz",
+			"integrity": "sha1-VPB9xW9HJgRi32phxUvvtEtXvlU=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-svg": "1.1.1",
+				"svgo": "0.6.6",
+				"through2": "2.0.3"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"import-local": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
+			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
+			}
+		},
+		"in-publish": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+			"integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+			"dev": true
+		},
+		"indent-string": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+			"dev": true,
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
+		"indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"ini": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+			"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+			"dev": true
+		},
+		"ink-docstrap": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ink-docstrap/-/ink-docstrap-1.3.0.tgz",
+			"integrity": "sha1-6QBeW7kCXMmpvo5ErYf4rViIyB0=",
+			"dev": true,
+			"requires": {
+				"moment": "2.19.1",
+				"sanitize-html": "1.14.1"
+			}
+		},
+		"inquirer": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+			"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "1.4.0",
+				"ansi-regex": "2.1.1",
+				"chalk": "1.1.3",
+				"cli-cursor": "1.0.2",
+				"cli-width": "2.2.0",
+				"figures": "1.7.0",
+				"lodash": "4.17.4",
+				"readline2": "1.0.1",
+				"run-async": "0.1.0",
+				"rx-lite": "3.1.2",
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"through": "2.3.8"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				}
+			}
+		},
+		"internal-ip": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
+			"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+			"dev": true,
+			"requires": {
+				"meow": "3.7.0"
+			}
+		},
+		"interpret": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+			"integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+			"dev": true
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
+		},
+		"ip": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+			"dev": true
+		},
+		"ip-regex": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
+			"integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=",
+			"dev": true,
+			"optional": true
+		},
+		"ipaddr.js": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+			"integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
+			"dev": true
+		},
+		"is-absolute": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+			"integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+			"dev": true,
+			"requires": {
+				"is-relative": "0.1.3"
+			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
+		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
+			"requires": {
+				"binary-extensions": "1.10.0"
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"dev": true,
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-bzip2": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
+			"integrity": "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w=",
+			"dev": true
+		},
+		"is-callable": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-fullwidth-code-point": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"dev": true,
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-gif": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-gif/-/is-gif-1.0.0.tgz",
+			"integrity": "sha1-ptKumIkwB7/6l6HYwB1jIFgyCX4=",
+			"dev": true,
+			"optional": true
+		},
+		"is-glob": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "2.1.1"
+			}
+		},
+		"is-gzip": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+			"integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=",
+			"dev": true
+		},
+		"is-jpg": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-1.0.0.tgz",
+			"integrity": "sha1-KVnBfnNDDbOCZNp1uQ3VTy2G2hw=",
+			"dev": true,
+			"optional": true
+		},
+		"is-my-json-valid": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+			"integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+			"dev": true,
+			"requires": {
+				"generate-function": "2.0.0",
+				"generate-object-property": "1.2.0",
+				"jsonpointer": "4.0.1",
+				"xtend": "4.0.1"
+			}
+		},
+		"is-natural-number": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
+			"integrity": "sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec=",
+			"dev": true
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
+			"requires": {
+				"is-path-inside": "1.0.0"
+			}
+		},
+		"is-path-inside": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+			"dev": true,
+			"requires": {
+				"path-is-inside": "1.0.2"
+			}
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
+			}
+		},
+		"is-png": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-png/-/is-png-1.1.0.tgz",
+			"integrity": "sha1-1XSxK/J1wDUEVVcLDltXqwYgd84=",
+			"dev": true,
+			"optional": true
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
+		},
+		"is-property": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
+		},
+		"is-redirect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+			"dev": true
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "1.0.1"
+			}
+		},
+		"is-relative": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+			"integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
+			"dev": true
+		},
+		"is-retry-allowed": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-svg": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz",
+			"integrity": "sha1-rA76r7ZTrFhHNwix+HNjbKEQ4xs=",
+			"dev": true,
+			"optional": true
+		},
+		"is-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
+		},
+		"is-tar": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
+			"integrity": "sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0=",
+			"dev": true
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
+		"is-url": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
+			"integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=",
+			"dev": true
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"is-valid-glob": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+			"dev": true
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
+		},
+		"is-zip": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
+			"integrity": "sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"jpegtran-bin": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-3.2.0.tgz",
+			"integrity": "sha1-9g7PSumZwL2tLp+83ytvCYHnops=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"bin-build": "2.2.0",
+				"bin-wrapper": "3.0.2",
+				"logalot": "2.1.0"
+			}
+		},
+		"js-base64": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
+			"integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+			"integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+			"dev": true,
+			"requires": {
+				"argparse": "0.1.16",
+				"esprima": "1.0.4"
+			}
+		},
+		"js2xmlparser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+			"integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+			"dev": true,
+			"requires": {
+				"xmlcreate": "1.0.2"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
+			"optional": true
+		},
+		"jsdoc": {
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
+			"integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+			"dev": true,
+			"requires": {
+				"babylon": "7.0.0-beta.19",
+				"bluebird": "3.5.1",
+				"catharsis": "0.8.9",
+				"escape-string-regexp": "1.0.5",
+				"js2xmlparser": "3.0.0",
+				"klaw": "2.0.0",
+				"marked": "0.3.6",
+				"mkdirp": "0.5.1",
+				"requizzle": "0.2.1",
+				"strip-json-comments": "2.0.1",
+				"taffydb": "2.6.2",
+				"underscore": "1.8.3"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				},
+				"klaw": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+					"integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11"
+					}
+				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+					"dev": true
+				}
+			}
+		},
+		"jshint": {
+			"version": "2.9.5",
+			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+			"integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+			"dev": true,
+			"requires": {
+				"cli": "1.0.1",
+				"console-browserify": "1.1.0",
+				"exit": "0.1.2",
+				"htmlparser2": "3.8.3",
+				"lodash": "3.7.0",
+				"minimatch": "3.0.4",
+				"shelljs": "0.3.0",
+				"strip-json-comments": "1.0.4"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "3.7.0",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+					"integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				},
+				"strip-json-comments": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+					"integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+					"dev": true
+				}
+			}
+		},
+		"json-loader": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+			"dev": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"json3": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+			"dev": true
+		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
+		},
+		"jsonfile": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
+		},
+		"jsonpointer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"kew": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+			"integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
+			"dev": true
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"klaw": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true
+		},
+		"lazy-req": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+			"integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
+			"dev": true,
+			"optional": true
+		},
+		"lazystream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
+			"requires": {
+				"invert-kv": "1.0.0"
+			}
+		},
+		"livereload-js": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
+			"integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
+			"dev": true
+		},
+		"load-json-file": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				}
+			}
+		},
+		"loader-runner": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+			"dev": true
+		},
+		"loader-utils": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"dev": true,
+			"requires": {
+				"big.js": "3.2.0",
+				"emojis-list": "2.1.0",
+				"json5": "0.5.1"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			},
+			"dependencies": {
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				}
+			}
+		},
+		"lodash": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+			"integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+			"dev": true
+		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+			"dev": true
+		},
+		"lodash._basetostring": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+			"dev": true
+		},
+		"lodash._basevalues": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+			"dev": true
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+			"dev": true
+		},
+		"lodash._reescape": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+			"dev": true
+		},
+		"lodash._reevaluate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+			"dev": true
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
+		},
+		"lodash._root": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+			"dev": true
+		},
+		"lodash.assign": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"dev": true
+		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
+		},
+		"lodash.escape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+			"dev": true,
+			"requires": {
+				"lodash._root": "3.0.1"
+			}
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"dev": true
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
+			"requires": {
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
+			}
+		},
+		"lodash.mergewith": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+			"dev": true
+		},
+		"lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+			"dev": true
+		},
+		"lodash.template": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+			"dev": true,
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash._basetostring": "3.0.1",
+				"lodash._basevalues": "3.0.0",
+				"lodash._isiterateecall": "3.0.9",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0",
+				"lodash.keys": "3.1.2",
+				"lodash.restparam": "3.6.1",
+				"lodash.templatesettings": "3.1.1"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0"
+			}
+		},
+		"logalot": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
+			"integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"figures": "1.7.0",
+				"squeak": "1.3.0"
+			}
+		},
+		"loglevel": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.1.tgz",
+			"integrity": "sha1-GJB4yUq5BT7iFaCs2/JCROoPZQI=",
+			"dev": true
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
+		},
+		"loud-rejection": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"dev": true,
+			"requires": {
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"lowercase-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+			"dev": true
+		},
+		"lpad-align": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz",
+			"integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"get-stdin": "4.0.1",
+				"indent-string": "2.1.0",
+				"longest": "1.0.1",
+				"meow": "3.7.0"
+			}
+		},
+		"lru-cache": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+			"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+			"dev": true
+		},
+		"map-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+			"dev": true
+		},
+		"marked": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+			"integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+			"dev": true
+		},
+		"matchdep": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/matchdep/-/matchdep-1.0.1.tgz",
+			"integrity": "sha1-pXozgESR+64girqPaDgEN6vC3KU=",
+			"dev": true,
+			"requires": {
+				"findup-sync": "0.3.0",
+				"micromatch": "2.3.11",
+				"resolve": "1.1.7",
+				"stack-trace": "0.0.9"
+			},
+			"dependencies": {
+				"findup-sync": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+					"integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+					"dev": true,
+					"requires": {
+						"glob": "5.0.15"
+					}
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				}
+			}
+		},
+		"maxmin": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
+			"integrity": "sha1-cTZehKmd2Piz99X94vANHn9zvmE=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"figures": "1.7.0",
+				"gzip-size": "1.0.0",
+				"pretty-bytes": "1.0.4"
+			},
+			"dependencies": {
+				"pretty-bytes": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+					"integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
+					"dev": true,
+					"requires": {
+						"get-stdin": "4.0.1",
+						"meow": "3.7.0"
+					}
+				}
+			}
+		},
+		"md5.js": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+			"dev": true,
+			"requires": {
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3"
+			},
+			"dependencies": {
+				"hash-base": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.3",
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+			"dev": true
+		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "1.1.0"
+			}
+		},
+		"memory-fs": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+			"dev": true,
+			"requires": {
+				"errno": "0.1.4",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"meow": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+			"dev": true,
+			"requires": {
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.4.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
+			}
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+			"dev": true
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+			"dev": true
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"miller-rabin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0"
+			}
+		},
+		"mime": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+			"dev": true
+		},
+		"mime-db": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.17",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"dev": true,
+			"requires": {
+				"mime-db": "1.30.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+			"dev": true
+		},
+		"minimalistic-assert": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
+			"dev": true
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "0.2.14",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+			"integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+			"dev": true,
+			"requires": {
+				"lru-cache": "2.7.3",
+				"sigmund": "1.0.1"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
+			}
+		},
+		"moment": {
+			"version": "2.19.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
+			"integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc=",
+			"dev": true
+		},
+		"ms": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+			"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+			"dev": true
+		},
+		"multicast-dns": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
+			"integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
+			"dev": true,
+			"requires": {
+				"dns-packet": "1.2.2",
+				"thunky": "0.1.0"
+			}
+		},
+		"multicast-dns-service-types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+			"dev": true
+		},
+		"multipipe": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+			"dev": true,
+			"requires": {
+				"duplexer2": "0.0.2"
+			},
+			"dependencies": {
+				"duplexer2": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+					"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "1.1.14"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
+		},
+		"mute-stream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+			"dev": true
+		},
+		"nan": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+			"dev": true
+		},
+		"negotiator": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+			"dev": true
+		},
+		"node-forge": {
+			"version": "0.6.33",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
+			"integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw=",
+			"dev": true
+		},
+		"node-gyp": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+			"integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+			"dev": true,
+			"requires": {
+				"fstream": "1.0.11",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"nopt": "3.0.6",
+				"npmlog": "4.1.2",
+				"osenv": "0.1.4",
+				"request": "2.81.0",
+				"rimraf": "2.2.8",
+				"semver": "5.3.0",
+				"tar": "2.2.1",
+				"which": "1.0.9"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				},
+				"nopt": {
+					"version": "3.0.6",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+					"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+					"dev": true,
+					"requires": {
+						"abbrev": "1.1.1"
+					}
+				},
+				"semver": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"dev": true
+				}
+			}
+		},
+		"node-libs-browser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
+			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+			"dev": true,
+			"requires": {
+				"assert": "1.4.1",
+				"browserify-zlib": "0.1.4",
+				"buffer": "4.9.1",
+				"console-browserify": "1.1.0",
+				"constants-browserify": "1.0.0",
+				"crypto-browserify": "3.11.1",
+				"domain-browser": "1.1.7",
+				"events": "1.1.1",
+				"https-browserify": "0.0.1",
+				"os-browserify": "0.2.1",
+				"path-browserify": "0.0.0",
+				"process": "0.11.10",
+				"punycode": "1.4.1",
+				"querystring-es3": "0.2.1",
+				"readable-stream": "2.3.3",
+				"stream-browserify": "2.0.1",
+				"stream-http": "2.7.2",
+				"string_decoder": "0.10.31",
+				"timers-browserify": "2.0.4",
+				"tty-browserify": "0.0.0",
+				"url": "0.11.0",
+				"util": "0.10.3",
+				"vm-browserify": "0.0.4"
+			},
+			"dependencies": {
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
+		},
+		"node-sass": {
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
+			"integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
+			"dev": true,
+			"requires": {
+				"async-foreach": "0.1.3",
+				"chalk": "1.1.3",
+				"cross-spawn": "3.0.1",
+				"gaze": "1.1.2",
+				"get-stdin": "4.0.1",
+				"glob": "7.1.2",
+				"in-publish": "2.0.0",
+				"lodash.assign": "4.2.0",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.mergewith": "4.6.1",
+				"meow": "3.7.0",
+				"mkdirp": "0.5.1",
+				"nan": "2.7.0",
+				"node-gyp": "3.6.2",
+				"npmlog": "4.1.2",
+				"request": "2.79.0",
+				"sass-graph": "2.2.4",
+				"stdout-stream": "1.4.0",
+				"true-case-path": "1.0.2"
+			},
+			"dependencies": {
+				"caseless": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+					"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+					"dev": true
+				},
+				"commander": {
+					"version": "2.14.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+					"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"har-validator": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+					"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+					"dev": true,
+					"requires": {
+						"chalk": "1.1.3",
+						"commander": "2.14.1",
+						"is-my-json-valid": "2.16.1",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				},
+				"qs": {
+					"version": "6.3.2",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+					"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+					"dev": true
+				},
+				"request": {
+					"version": "2.79.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+					"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+					"dev": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.11.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "2.0.6",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.17",
+						"oauth-sign": "0.8.2",
+						"qs": "6.3.2",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.3",
+						"tunnel-agent": "0.4.3",
+						"uuid": "3.2.1"
+					}
+				},
+				"uuid": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+					"dev": true
+				}
+			}
+		},
+		"node-status-codes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+			"integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
+			"dev": true
+		},
+		"node-uuid": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+			"integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+			"dev": true
+		},
+		"nopt": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+			"integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1.1.1"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "2.5.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.4.1",
+				"validate-npm-package-license": "3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"normalize-range": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+			"dev": true
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"npmlog": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
+			"requires": {
+				"are-we-there-yet": "1.1.4",
+				"console-control-strings": "1.1.0",
+				"gauge": "2.7.4",
+				"set-blocking": "2.0.0"
+			}
+		},
+		"num2fraction": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+			"dev": true
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
+		},
+		"object-keys": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"obuf": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
+			"integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4=",
+			"dev": true
+		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"dev": true,
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
+		"on-headers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+			"dev": true
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"onetime": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+			"dev": true
+		},
+		"opn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
+			"integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+			"dev": true,
+			"requires": {
+				"is-wsl": "1.1.0"
+			}
+		},
+		"optional": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
+			"integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
+			"dev": true
+		},
+		"optipng-bin": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/optipng-bin/-/optipng-bin-3.1.4.tgz",
+			"integrity": "sha1-ldNPLEiHBPb9cGBr/qDGWfHZXYQ=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"bin-build": "2.2.0",
+				"bin-wrapper": "3.0.2",
+				"logalot": "2.1.0"
+			}
+		},
+		"ordered-read-streams": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+			"dev": true,
+			"requires": {
+				"is-stream": "1.1.0",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"original": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+			"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+			"dev": true,
+			"requires": {
+				"url-parse": "1.0.5"
+			},
+			"dependencies": {
+				"url-parse": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+					"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+					"dev": true,
+					"requires": {
+						"querystringify": "0.0.4",
+						"requires-port": "1.0.0"
+					}
+				}
+			}
+		},
+		"os-browserify": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+			"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+			"dev": true
+		},
+		"os-filter-obj": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
+			"integrity": "sha1-WRUzDZDs7VV9LZOKMcbdIU2cY60=",
+			"dev": true,
+			"optional": true
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
+		},
+		"os-locale": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"dev": true,
+			"requires": {
+				"lcid": "1.0.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
+		},
+		"osenv": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+			"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+			"dev": true,
+			"requires": {
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"p-limit": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+			"dev": true
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
+			"requires": {
+				"p-limit": "1.1.0"
+			}
+		},
+		"p-map": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"dev": true
+		},
+		"package": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
+			"integrity": "sha1-0lofmeJQbcsn1nBLg9yooxLk7cw=",
+			"dev": true
+		},
+		"pako": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+			"dev": true
+		},
+		"parse-asn1": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+			"dev": true,
+			"requires": {
+				"asn1.js": "4.9.1",
+				"browserify-aes": "1.1.1",
+				"create-hash": "1.1.3",
+				"evp_bytestokey": "1.0.3",
+				"pbkdf2": "3.0.14"
+			}
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"parseurl": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+			"dev": true
+		},
+		"path-browserify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+			"dev": true
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true
+		},
+		"path-exists": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+			"dev": true,
+			"requires": {
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
+		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+			"dev": true
+		},
+		"path-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				}
+			}
+		},
+		"pbkdf2": {
+			"version": "3.0.14",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+			"dev": true,
+			"requires": {
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"ripemd160": "2.0.1",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.9"
+			}
+		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+			"dev": true
+		},
+		"performance-now": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+			"dev": true
+		},
+		"phantomjs-prebuilt": {
+			"version": "2.1.15",
+			"resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.15.tgz",
+			"integrity": "sha1-IPhugtM0nFBZF1J3RbekEeCLOQM=",
+			"dev": true,
+			"requires": {
+				"es6-promise": "4.0.5",
+				"extract-zip": "1.6.5",
+				"fs-extra": "1.0.0",
+				"hasha": "2.2.0",
+				"kew": "0.7.0",
+				"progress": "1.1.8",
+				"request": "2.81.0",
+				"request-progress": "2.0.1",
+				"which": "1.2.14"
+			},
+			"dependencies": {
+				"which": {
+					"version": "1.2.14",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+					"integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+					"dev": true,
+					"requires": {
+						"isexe": "2.0.0"
+					}
+				}
+			}
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
+			"requires": {
+				"find-up": "2.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				}
+			}
+		},
+		"portfinder": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+			"dev": true,
+			"requires": {
+				"async": "1.5.2",
+				"debug": "2.2.0",
+				"mkdirp": "0.5.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				}
+			}
+		},
+		"postcss": {
+			"version": "5.2.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+			"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"js-base64": "2.3.2",
+				"source-map": "0.5.7",
+				"supports-color": "3.2.3"
+			}
+		},
+		"postcss-value-parser": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+			"dev": true
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+			"dev": true
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
+		},
+		"pretty-bytes": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+			"integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
+			"dev": true,
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+			"dev": true
+		},
+		"process-nextick-args": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+			"dev": true
+		},
+		"progress": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+			"dev": true
+		},
+		"proxy-addr": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+			"integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+			"dev": true,
+			"requires": {
+				"forwarded": "0.1.2",
+				"ipaddr.js": "1.5.2"
+			}
+		},
+		"prr": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+			"dev": true
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
+		},
+		"public-encrypt": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.1.3",
+				"parse-asn1": "5.1.0",
+				"randombytes": "2.0.5"
+			}
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
+		},
+		"q": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+			"dev": true,
+			"optional": true
+		},
+		"qs": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+			"dev": true
+		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"dev": true
+		},
+		"querystring-es3": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+			"dev": true
+		},
+		"querystringify": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+			"integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
+			"dev": true
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"randombytes": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+			"dev": true
+		},
+		"raw-body": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+			"integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
+			"dev": true,
+			"requires": {
+				"bytes": "2.4.0",
+				"iconv-lite": "0.4.13",
+				"unpipe": "1.0.0"
+			},
+			"dependencies": {
+				"bytes": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+					"integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
+					"dev": true
+				},
+				"iconv-lite": {
+					"version": "0.4.13",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+					"integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+					"dev": true
+				}
+			}
+		},
+		"rc": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+			"integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+			"dev": true,
+			"requires": {
+				"deep-extend": "0.4.2",
+				"ini": "1.3.4",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
+			}
+		},
+		"read-all-stream": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+			"integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+			"dev": true,
+			"requires": {
+				"pinkie-promise": "2.0.1",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"read-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"dev": true,
+			"requires": {
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "1.0.7",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"readdirp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.3",
+				"set-immediate-shim": "1.0.1"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				}
+			}
+		},
+		"readline2": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+			"dev": true,
+			"requires": {
+				"code-point-at": "1.1.0",
+				"is-fullwidth-code-point": "1.0.0",
+				"mute-stream": "0.0.5"
+			}
+		},
+		"redent": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+			"dev": true,
+			"requires": {
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
+			}
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"regexp-quote": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz",
+			"integrity": "sha1-Hg9GUMhi3L/tVP1CsUjpuxch/PI=",
+			"dev": true
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
+			"requires": {
+				"is-finite": "1.0.2"
+			}
+		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+			"dev": true
+		},
+		"request": {
+			"version": "2.81.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "0.6.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.5",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.1.4",
+				"har-validator": "4.2.1",
+				"hawk": "3.1.3",
+				"http-signature": "1.1.1",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.17",
+				"oauth-sign": "0.8.2",
+				"performance-now": "0.2.0",
+				"qs": "6.4.0",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.3",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.1.0"
+			},
+			"dependencies": {
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"uuid": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+					"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+					"dev": true
+				}
+			}
+		},
+		"request-progress": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+			"integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+			"dev": true,
+			"requires": {
+				"throttleit": "1.0.0"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
+		},
+		"requizzle": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+			"integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+			"dev": true,
+			"requires": {
+				"underscore": "1.6.0"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+					"dev": true
+				}
+			}
+		},
+		"resolve": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+			"dev": true
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
+			"requires": {
+				"resolve-from": "3.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+			"dev": true
+		},
+		"restore-cursor": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+			"dev": true,
+			"requires": {
+				"exit-hook": "1.1.1",
+				"onetime": "1.1.0"
+			}
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+			"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+			"dev": true
+		},
+		"ripemd160": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+			"dev": true,
+			"requires": {
+				"hash-base": "2.0.2",
+				"inherits": "2.0.3"
+			}
+		},
+		"rtlcss": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.2.0.tgz",
+			"integrity": "sha1-E0QVJU0MJrXEA+Lq0sG4v0/AAN0=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"findup": "0.1.5",
+				"mkdirp": "0.5.1",
+				"postcss": "6.0.13",
+				"strip-json-comments": "2.0.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.13",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
+					"integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.0",
+						"source-map": "0.6.1",
+						"supports-color": "4.5.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+							"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "3.2.0",
+								"escape-string-regexp": "1.0.5",
+								"supports-color": "4.5.0"
+							}
+						}
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				}
+			}
+		},
+		"run-async": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"rx-lite": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+			"dev": true
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
+		},
+		"sanitize-html": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.14.1.tgz",
+			"integrity": "sha1-cw/6Ikm98YMz7/5FsoYXPJxa0Lg=",
+			"dev": true,
+			"requires": {
+				"htmlparser2": "3.9.2",
+				"regexp-quote": "0.0.0",
+				"xtend": "4.0.1"
+			},
+			"dependencies": {
+				"entities": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+					"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+					"dev": true
+				},
+				"htmlparser2": {
+					"version": "3.9.2",
+					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+					"integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+					"dev": true,
+					"requires": {
+						"domelementtype": "1.3.0",
+						"domhandler": "2.3.0",
+						"domutils": "1.5.1",
+						"entities": "1.1.1",
+						"inherits": "2.0.3",
+						"readable-stream": "2.3.3"
+					}
+				}
+			}
+		},
+		"sass-graph": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2",
+				"lodash": "4.17.5",
+				"scss-tokenizer": "0.2.3",
+				"yargs": "7.1.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.5",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				},
+				"yargs": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+					"dev": true,
+					"requires": {
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "5.0.0"
+					}
+				}
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
+		},
+		"scss-tokenizer": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+			"dev": true,
+			"requires": {
+				"js-base64": "2.3.2",
+				"source-map": "0.4.4"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"seek-bzip": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+			"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+			"dev": true,
+			"requires": {
+				"commander": "2.8.1"
+			}
+		},
+		"select-hose": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+			"dev": true
+		},
+		"selfsigned": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz",
+			"integrity": "sha1-v4y3uDJWxFUeMTR8YxF3jbme7FI=",
+			"dev": true,
+			"requires": {
+				"node-forge": "0.6.33"
+			}
+		},
+		"semver": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+			"dev": true
+		},
+		"semver-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
+			"integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
+			"dev": true,
+			"optional": true
+		},
+		"semver-truncate": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
+			"integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"semver": "5.4.1"
+			}
+		},
+		"send": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+			"integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "1.1.1",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "1.6.2",
+				"mime": "1.4.1",
+				"ms": "2.0.0",
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.3.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"http-errors": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+					"dev": true,
+					"requires": {
+						"depd": "1.1.1",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.0.3",
+						"statuses": "1.3.1"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"setprototypeof": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+					"dev": true
+				},
+				"statuses": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+					"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+					"dev": true
+				}
+			}
+		},
+		"serve-index": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+			"dev": true,
+			"requires": {
+				"accepts": "1.3.4",
+				"batch": "0.6.1",
+				"debug": "2.6.9",
+				"escape-html": "1.0.3",
+				"http-errors": "1.6.2",
+				"mime-types": "2.1.17",
+				"parseurl": "1.3.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"http-errors": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+					"dev": true,
+					"requires": {
+						"depd": "1.1.1",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.0.3",
+						"statuses": "1.4.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"setprototypeof": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+					"dev": true
+				}
+			}
+		},
+		"serve-static": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+			"integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+			"dev": true,
+			"requires": {
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.2",
+				"send": "0.16.1"
+			}
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
+		},
+		"set-immediate-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
+		},
+		"setprototypeof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+			"dev": true
+		},
+		"sha.js": {
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
+			"integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
+		},
+		"shelljs": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+			"integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+			"dev": true
+		},
+		"sigmund": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"sntp": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"dev": true,
+			"requires": {
+				"hoek": "2.16.3"
+			}
+		},
+		"sockjs": {
+			"version": "0.3.18",
+			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
+			"integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
+			"dev": true,
+			"requires": {
+				"faye-websocket": "0.10.0",
+				"uuid": "2.0.3"
+			}
+		},
+		"sockjs-client": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+			"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"eventsource": "0.1.6",
+				"faye-websocket": "0.11.1",
+				"inherits": "2.0.3",
+				"json3": "3.3.2",
+				"url-parse": "1.1.9"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"faye-websocket": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+					"dev": true,
+					"requires": {
+						"websocket-driver": "0.7.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"source-list-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+			"dev": true
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
+		},
+		"sparkles": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+			"dev": true
+		},
+		"spdx-correct": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"dev": true,
+			"requires": {
+				"spdx-license-ids": "1.2.2"
+			}
+		},
+		"spdx-expression-parse": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+			"dev": true
+		},
+		"spdx-license-ids": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+			"dev": true
+		},
+		"spdy": {
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"handle-thing": "1.2.5",
+				"http-deceiver": "1.2.7",
+				"safe-buffer": "5.1.1",
+				"select-hose": "2.0.0",
+				"spdy-transport": "2.0.20"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"spdy-transport": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
+			"integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"detect-node": "2.0.3",
+				"hpack.js": "2.1.6",
+				"obuf": "1.1.1",
+				"readable-stream": "2.3.3",
+				"safe-buffer": "5.1.1",
+				"wbuf": "1.7.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"squeak": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
+			"integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"console-stream": "0.1.1",
+				"lpad-align": "1.1.2"
+			}
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"dev": true,
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"stack-trace": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+			"integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
+			"dev": true
+		},
+		"stat-mode": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+			"integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+			"dev": true
+		},
+		"statuses": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+			"dev": true
+		},
+		"stdout-stream": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+			"integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"stream-browserify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"stream-buffers": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+			"integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+			"dev": true
+		},
+		"stream-combiner2": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+			"integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+			"dev": true,
+			"requires": {
+				"duplexer2": "0.1.4",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"stream-http": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+			"dev": true,
+			"requires": {
+				"builtin-status-codes": "3.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"to-arraybuffer": "1.0.1",
+				"xtend": "4.0.1"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+			"dev": true
+		},
+		"string-width": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"dev": true,
+			"requires": {
+				"code-point-at": "1.1.0",
+				"is-fullwidth-code-point": "1.0.0",
+				"strip-ansi": "3.0.1"
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"dev": true
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"strip-bom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"dev": true,
+			"requires": {
+				"is-utf8": "0.2.1"
+			}
+		},
+		"strip-bom-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+			"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+			"dev": true,
+			"requires": {
+				"first-chunk-stream": "1.0.0",
+				"strip-bom": "2.0.0"
+			}
+		},
+		"strip-dirs": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+			"integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"get-stdin": "4.0.1",
+				"is-absolute": "0.1.7",
+				"is-natural-number": "2.1.1",
+				"minimist": "1.2.0",
+				"sum-up": "1.0.3"
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
+		},
+		"strip-indent": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+			"dev": true,
+			"requires": {
+				"get-stdin": "4.0.1"
+			}
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"strip-outer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+			"integrity": "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"sum-up": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
+			"integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3"
+			}
+		},
+		"supports-color": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+			"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+			"dev": true,
+			"requires": {
+				"has-flag": "1.0.0"
+			}
+		},
+		"svgo": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz",
+			"integrity": "sha1-s0CIkDbyD5tEdUMHfQ9Vc+0ETAg=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"coa": "1.0.4",
+				"colors": "1.1.2",
+				"csso": "2.0.0",
+				"js-yaml": "3.6.1",
+				"mkdirp": "0.5.1",
+				"sax": "1.2.4",
+				"whet.extend": "0.9.9"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "1.0.9",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+					"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"sprintf-js": "1.0.3"
+					}
+				},
+				"colors": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+					"dev": true,
+					"optional": true
+				},
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true,
+					"optional": true
+				},
+				"js-yaml": {
+					"version": "3.6.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+					"integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"argparse": "1.0.9",
+						"esprima": "2.7.3"
+					}
+				}
+			}
+		},
+		"taffydb": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+			"dev": true
+		},
+		"tapable": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+			"dev": true
+		},
+		"tar": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+			"dev": true,
+			"requires": {
+				"block-stream": "0.0.9",
+				"fstream": "1.0.11",
+				"inherits": "2.0.3"
+			}
+		},
+		"tar-stream": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+			"integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+			"dev": true,
+			"requires": {
+				"bl": "1.2.1",
+				"end-of-stream": "1.4.0",
+				"readable-stream": "2.3.3",
+				"xtend": "4.0.1"
+			}
+		},
+		"tempfile": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+			"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "1.0.2",
+				"uuid": "2.0.3"
+			}
+		},
+		"temporary": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
+			"integrity": "sha1-oYqYHSi6jKNgJ/s8MFOMPst0CsA=",
+			"dev": true,
+			"requires": {
+				"package": "1.0.1"
+			}
+		},
+		"throttleit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+			"integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+			"dev": true
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"through2": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+			"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "1.0.34",
+				"xtend": "4.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
+		},
+		"through2-filter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"dev": true,
+			"requires": {
+				"through2": "2.0.3",
+				"xtend": "4.0.1"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"thunky": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
+			"integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4=",
+			"dev": true
+		},
+		"time-stamp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+			"dev": true
+		},
+		"timed-out": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+			"integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
+			"dev": true
+		},
+		"timers-browserify": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
+			"integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+			"dev": true,
+			"requires": {
+				"setimmediate": "1.0.5"
+			}
+		},
+		"tiny-lr": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
+			"integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
+			"dev": true,
+			"requires": {
+				"body-parser": "1.14.2",
+				"debug": "2.2.0",
+				"faye-websocket": "0.10.0",
+				"livereload-js": "2.2.2",
+				"parseurl": "1.3.2",
+				"qs": "5.1.0"
+			},
+			"dependencies": {
+				"qs": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
+					"integrity": "sha1-TZMuXH6kEcynajEtOaYGIA/VDNk=",
+					"dev": true
+				}
+			}
+		},
+		"to-absolute-glob": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "2.0.1"
+			}
+		},
+		"to-arraybuffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+			"dev": true
+		},
+		"tough-cookie": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"dev": true,
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"trim-newlines": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+			"dev": true
+		},
+		"trim-repeated": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"true-case-path": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
+			"integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
+			"dev": true,
+			"requires": {
+				"glob": "6.0.4"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "6.0.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+					"dev": true,
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				}
+			}
+		},
+		"tty-browserify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+			"dev": true
+		},
+		"tunnel-agent": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+			"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+			"dev": true
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
+			"optional": true
+		},
+		"type-is": {
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+			"integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+			"dev": true,
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "2.1.17"
+			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
+		"uglify-js": {
+			"version": "2.7.5",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+			"integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
+			"dev": true,
+			"requires": {
+				"async": "0.2.10",
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "0.2.10",
+					"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+					"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+					"dev": true
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true
+		},
+		"uglifyjs-webpack-plugin": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+			"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+			"dev": true,
+			"requires": {
+				"source-map": "0.5.7",
+				"uglify-js": "2.8.29",
+				"webpack-sources": "1.0.1"
+			},
+			"dependencies": {
+				"uglify-js": {
+					"version": "2.8.29",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+					"dev": true,
+					"requires": {
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
+					}
+				}
+			}
+		},
+		"underscore-contrib": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+			"integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+			"dev": true,
+			"requires": {
+				"underscore": "1.6.0"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+					"dev": true
+				}
+			}
+		},
+		"underscore.string": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+			"integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+			"dev": true
+		},
+		"unique-stream": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+			"dev": true,
+			"requires": {
+				"json-stable-stringify": "1.0.1",
+				"through2-filter": "2.0.0"
+			}
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+			"dev": true
+		},
+		"unzip-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+			"integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+			"dev": true
+		},
+		"uri-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/uri-path/-/uri-path-1.0.0.tgz",
+			"integrity": "sha1-l0fwGDWJM8Md4PzP2C0TjmcmLjI=",
+			"dev": true
+		},
+		"url": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"dev": true,
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+					"dev": true
+				}
+			}
+		},
+		"url-parse": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+			"integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+			"dev": true,
+			"requires": {
+				"querystringify": "1.0.0",
+				"requires-port": "1.0.0"
+			},
+			"dependencies": {
+				"querystringify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+					"integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+					"dev": true
+				}
+			}
+		},
+		"url-parse-lax": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"dev": true,
+			"requires": {
+				"prepend-http": "1.0.4"
+			}
+		},
+		"url-regex": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
+			"integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"ip-regex": "1.0.3"
+			}
+		},
+		"util": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.1"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+					"dev": true
+				}
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+			"dev": true
+		},
+		"uuid": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+			"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+			"dev": true
+		},
+		"vali-date": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"dev": true,
+			"requires": {
+				"spdx-correct": "1.0.2",
+				"spdx-expression-parse": "1.0.4"
+			}
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+			"dev": true
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"vinyl": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+			"dev": true,
+			"requires": {
+				"clone": "1.0.2",
+				"clone-stats": "0.0.1",
+				"replace-ext": "0.0.1"
+			}
+		},
+		"vinyl-assign": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
+			"integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
+			"dev": true,
+			"requires": {
+				"object-assign": "4.1.1",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"vinyl-fs": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+			"dev": true,
+			"requires": {
+				"duplexify": "3.5.1",
+				"glob-stream": "5.3.5",
+				"graceful-fs": "4.1.11",
+				"gulp-sourcemaps": "1.6.0",
+				"is-valid-glob": "0.3.0",
+				"lazystream": "1.0.0",
+				"lodash.isequal": "4.5.0",
+				"merge-stream": "1.0.1",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1",
+				"readable-stream": "2.3.3",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "1.0.0",
+				"through2": "2.0.3",
+				"through2-filter": "2.0.0",
+				"vali-date": "1.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				},
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"vm-browserify": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+			"dev": true,
+			"requires": {
+				"indexof": "0.0.1"
+			}
+		},
+		"walkdir": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+			"integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
+			"dev": true
+		},
+		"ware": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+			"integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
+			"dev": true,
+			"requires": {
+				"wrap-fn": "0.1.5"
+			}
+		},
+		"watchpack": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
+			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+			"dev": true,
+			"requires": {
+				"async": "2.5.0",
+				"chokidar": "1.7.0",
+				"graceful-fs": "4.1.11"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+					"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+					"dev": true,
+					"requires": {
+						"lodash": "4.17.4"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				}
+			}
+		},
+		"wbuf": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
+			"integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
+			"dev": true,
+			"requires": {
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"webpack": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
+			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+			"dev": true,
+			"requires": {
+				"acorn": "5.2.1",
+				"acorn-dynamic-import": "2.0.2",
+				"ajv": "5.3.0",
+				"ajv-keywords": "2.1.1",
+				"async": "2.5.0",
+				"enhanced-resolve": "3.4.1",
+				"escope": "3.6.0",
+				"interpret": "1.0.4",
+				"json-loader": "0.5.7",
+				"json5": "0.5.1",
+				"loader-runner": "2.3.0",
+				"loader-utils": "1.1.0",
+				"memory-fs": "0.4.1",
+				"mkdirp": "0.5.1",
+				"node-libs-browser": "2.0.0",
+				"source-map": "0.5.7",
+				"supports-color": "4.5.0",
+				"tapable": "0.2.8",
+				"uglifyjs-webpack-plugin": "0.4.6",
+				"watchpack": "1.4.0",
+				"webpack-sources": "1.0.1",
+				"yargs": "8.0.2"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+					"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+					"dev": true,
+					"requires": {
+						"co": "4.6.0",
+						"fast-deep-equal": "1.0.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"async": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+					"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+					"dev": true,
+					"requires": {
+						"lodash": "4.17.4"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"dev": true,
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"co": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+					"dev": true
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"dev": true,
+					"requires": {
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"dev": true,
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"dev": true,
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+							"dev": true
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+					"dev": true
+				},
+				"yargs": {
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+					"dev": true,
+					"requires": {
+						"camelcase": "4.1.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"read-pkg-up": "2.0.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "7.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+					"dev": true,
+					"requires": {
+						"camelcase": "4.1.0"
+					}
+				}
+			}
+		},
+		"webpack-dev-middleware": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
+			"integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
+			"dev": true,
+			"requires": {
+				"memory-fs": "0.4.1",
+				"mime": "1.4.1",
+				"path-is-absolute": "1.0.1",
+				"range-parser": "1.2.0",
+				"time-stamp": "2.0.0"
+			},
+			"dependencies": {
+				"time-stamp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+					"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
+					"dev": true
+				}
+			}
+		},
+		"webpack-dev-server": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.3.tgz",
+			"integrity": "sha512-bwq7sj452FRH+oVfgOA8xXKkLYPTNsYB4dQ0Jhz3ydjNJ9MvhpGJtehFW8Z0cEcwNkRRiF4aYbReiSGQ4pbS1w==",
+			"dev": true,
+			"requires": {
+				"ansi-html": "0.0.7",
+				"array-includes": "3.0.3",
+				"bonjour": "3.5.0",
+				"chokidar": "1.7.0",
+				"compression": "1.7.1",
+				"connect-history-api-fallback": "1.4.0",
+				"debug": "3.1.0",
+				"del": "3.0.0",
+				"express": "4.16.2",
+				"html-entities": "1.2.1",
+				"http-proxy-middleware": "0.17.4",
+				"import-local": "0.1.1",
+				"internal-ip": "1.2.0",
+				"ip": "1.1.5",
+				"loglevel": "1.5.1",
+				"opn": "5.1.0",
+				"portfinder": "1.0.13",
+				"selfsigned": "1.10.1",
+				"serve-index": "1.9.1",
+				"sockjs": "0.3.18",
+				"sockjs-client": "1.1.4",
+				"spdy": "3.4.7",
+				"strip-ansi": "3.0.1",
+				"supports-color": "4.5.0",
+				"webpack-dev-middleware": "1.12.0",
+				"yargs": "6.6.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				},
+				"yargs": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+					"dev": true,
+					"requires": {
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "4.2.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+					"dev": true,
+					"requires": {
+						"camelcase": "3.0.0"
+					}
+				}
+			}
+		},
+		"webpack-sources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
+			"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+			"dev": true,
+			"requires": {
+				"source-list-map": "2.0.0",
+				"source-map": "0.5.7"
+			}
+		},
+		"websocket-driver": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+			"dev": true,
+			"requires": {
+				"http-parser-js": "0.4.9",
+				"websocket-extensions": "0.1.2"
+			}
+		},
+		"websocket-extensions": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
+			"integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=",
+			"dev": true
+		},
+		"whet.extend": {
+			"version": "0.9.9",
+			"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+			"dev": true,
+			"optional": true
+		},
+		"which": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+			"integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+			"dev": true
+		},
+		"which-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+			"dev": true
+		},
+		"wide-align": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+			"dev": true,
+			"requires": {
+				"string-width": "1.0.2"
+			}
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true
+		},
+		"wordwrap": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			}
+		},
+		"wrap-fn": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
+			"integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
+			"dev": true,
+			"requires": {
+				"co": "3.1.0"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"xmlbuilder": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+			"integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+			"dev": true
+		},
+		"xmlcreate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+			"integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
+			"dev": true
+		},
+		"xmlrpc": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/xmlrpc/-/xmlrpc-1.3.2.tgz",
+			"integrity": "sha1-JrLqNHhI0Ciqx+dRS1NRl23j6D0=",
+			"dev": true,
+			"requires": {
+				"sax": "1.2.4",
+				"xmlbuilder": "8.2.2"
+			}
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
+		},
+		"y18n": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"dev": true
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
+		},
+		"yargs": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+			"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+			"dev": true,
+			"requires": {
+				"camelcase": "1.2.1",
+				"cliui": "2.1.0",
+				"decamelize": "1.2.0",
+				"window-size": "0.1.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+					"dev": true
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+			"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+			"dev": true,
+			"requires": {
+				"camelcase": "3.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
+				}
+			}
+		},
+		"yauzl": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+			"integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+			"dev": true,
+			"requires": {
+				"buffer-crc32": "0.2.13",
+				"fd-slicer": "1.0.1"
+			}
+		},
+		"zip-stream": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+			"integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+			"dev": true,
+			"requires": {
+				"archiver-utils": "1.3.0",
+				"compress-commons": "1.2.2",
+				"lodash": "4.17.4",
+				"readable-stream": "2.3.3"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.4",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"dev": true
+				}
+			}
+		}
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,7 +35,7 @@
         <const name="WP_RUN_CORE_TESTS" value="1" />
     </php>
 	<listeners>
-		<listener class="SpeedTrapListener" file="tests/phpunit/includes/speed-trap-listener.php">
+		<listener class="SpeedTrapListener" file="tests/phpunit/includes/listener-loader.php">
 			<arguments>
 				<array>
 					<element key="slowThreshold">

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -1,0 +1,1081 @@
+<?php
+
+require_once dirname( __FILE__ ) . '/factory.php';
+require_once dirname( __FILE__ ) . '/trac.php';
+
+/**
+ * Defines a basic fixture to run multiple tests.
+ *
+ * Resets the state of the WordPress installation before and after every test.
+ *
+ * Includes utility functions and assertions useful for testing WordPress.
+ *
+ * All WordPress unit tests should inherit from this class.
+ */
+abstract class WP_UnitTestCase_Base extends PHPUnit_Framework_TestCase {
+
+	protected static $forced_tickets   = array();
+	protected $expected_deprecated     = array();
+	protected $caught_deprecated       = array();
+	protected $expected_doing_it_wrong = array();
+	protected $caught_doing_it_wrong   = array();
+
+	protected static $hooks_saved = array();
+	protected static $ignore_files;
+
+	function __isset( $name ) {
+		return 'factory' === $name;
+	}
+
+	function __get( $name ) {
+		if ( 'factory' === $name ) {
+			return self::factory();
+		}
+	}
+
+	/**
+	 * Fetches the factory object for generating WordPress fixtures.
+	 *
+	 * @return WP_UnitTest_Factory The fixture factory.
+	 */
+	protected static function factory() {
+		static $factory = null;
+		if ( ! $factory ) {
+			$factory = new WP_UnitTest_Factory();
+		}
+		return $factory;
+	}
+
+	public static function get_called_class() {
+		if ( function_exists( 'get_called_class' ) ) {
+			return get_called_class();
+		}
+
+		// PHP 5.2 only
+		$backtrace = debug_backtrace();
+		// [0] WP_UnitTestCase::get_called_class()
+		// [1] WP_UnitTestCase::setUpBeforeClass()
+		if ( 'call_user_func' === $backtrace[2]['function'] ) {
+			return $backtrace[2]['args'][0][0];
+		}
+		return $backtrace[2]['class'];
+	}
+
+	public static function setUpBeforeClass() {
+		global $wpdb;
+
+		$wpdb->suppress_errors = false;
+		$wpdb->show_errors     = true;
+		$wpdb->db_connect();
+		ini_set( 'display_errors', 1 );
+
+		parent::setUpBeforeClass();
+
+		$c = self::get_called_class();
+		if ( ! method_exists( $c, 'wpSetUpBeforeClass' ) ) {
+			self::commit_transaction();
+			return;
+		}
+
+		call_user_func( array( $c, 'wpSetUpBeforeClass' ), self::factory() );
+
+		self::commit_transaction();
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		_delete_all_data();
+		self::flush_cache();
+
+		$c = self::get_called_class();
+		if ( ! method_exists( $c, 'wpTearDownAfterClass' ) ) {
+			self::commit_transaction();
+			return;
+		}
+
+		call_user_func( array( $c, 'wpTearDownAfterClass' ) );
+
+		self::commit_transaction();
+	}
+
+	function setUp() {
+		set_time_limit( 0 );
+
+		if ( ! self::$ignore_files ) {
+			self::$ignore_files = $this->scan_user_uploads();
+		}
+
+		if ( ! self::$hooks_saved ) {
+			$this->_backup_hooks();
+		}
+
+		global $wp_rewrite;
+
+		$this->clean_up_global_scope();
+
+		/*
+		 * When running core tests, ensure that post types and taxonomies
+		 * are reset for each test. We skip this step for non-core tests,
+		 * given the large number of plugins that register post types and
+		 * taxonomies at 'init'.
+		 */
+		if ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
+			$this->reset_post_types();
+			$this->reset_taxonomies();
+			$this->reset_post_statuses();
+			$this->reset__SERVER();
+
+			if ( $wp_rewrite->permalink_structure ) {
+				$this->set_permalink_structure( '' );
+			}
+		}
+
+		$this->start_transaction();
+		$this->expectDeprecated();
+		add_filter( 'wp_die_handler', array( $this, 'get_wp_die_handler' ) );
+	}
+
+	/**
+	 * Detect post-test failure conditions.
+	 *
+	 * We use this method to detect expectedDeprecated and expectedIncorrectUsage annotations.
+	 *
+	 * @since 4.2.0
+	 */
+	protected function assertPostConditions() {
+		$this->expectedDeprecated();
+	}
+
+	/**
+	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 */
+	function tearDown() {
+		global $wpdb, $wp_query, $wp;
+		$wpdb->query( 'ROLLBACK' );
+		if ( is_multisite() ) {
+			while ( ms_is_switched() ) {
+				restore_current_blog();
+			}
+		}
+		$wp_query = new WP_Query();
+		$wp       = new WP();
+
+		// Reset globals related to the post loop and `setup_postdata()`.
+		$post_globals = array( 'post', 'id', 'authordata', 'currentday', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages' );
+		foreach ( $post_globals as $global ) {
+			$GLOBALS[ $global ] = null;
+		}
+
+		remove_theme_support( 'html5' );
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+		remove_filter( 'wp_die_handler', array( $this, 'get_wp_die_handler' ) );
+		$this->_restore_hooks();
+		wp_set_current_user( 0 );
+	}
+
+	function clean_up_global_scope() {
+		$_GET  = array();
+		$_POST = array();
+		self::flush_cache();
+	}
+
+	/**
+	 * Allow tests to be skipped on some automated runs
+	 *
+	 * For test runs on Travis for something other than trunk/master
+	 * we want to skip tests that only need to run for master.
+	 */
+	public function skipOnAutomatedBranches() {
+		// gentenv can be disabled
+		if ( ! function_exists( 'getenv' ) ) {
+			return false;
+		}
+
+		// https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+		$travis_branch       = getenv( 'TRAVIS_BRANCH' );
+		$travis_pull_request = getenv( 'TRAVIS_PULL_REQUEST' );
+
+		if ( false !== $travis_pull_request && 'master' !== $travis_branch ) {
+			$this->markTestSkipped( 'For automated test runs, this test is only run on trunk/master' );
+		}
+	}
+
+	/**
+	 * Allow tests to be skipped when Multisite is not in use.
+	 *
+	 * Use in conjunction with the ms-required group.
+	 */
+	public function skipWithoutMultisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Test only runs on Multisite' );
+		}
+	}
+
+	/**
+	 * Allow tests to be skipped when Multisite is in use.
+	 *
+	 * Use in conjunction with the ms-excluded group.
+	 */
+	public function skipWithMultisite() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Test does not run on Multisite' );
+		}
+	}
+
+	/**
+	 * Unregister existing post types and register defaults.
+	 *
+	 * Run before each test in order to clean up the global scope, in case
+	 * a test forgets to unregister a post type on its own, or fails before
+	 * it has a chance to do so.
+	 */
+	protected function reset_post_types() {
+		foreach ( get_post_types( array(), 'objects' ) as $pt ) {
+			if ( empty( $pt->tests_no_auto_unregister ) ) {
+				_unregister_post_type( $pt->name );
+			}
+		}
+		create_initial_post_types();
+	}
+
+	/**
+	 * Unregister existing taxonomies and register defaults.
+	 *
+	 * Run before each test in order to clean up the global scope, in case
+	 * a test forgets to unregister a taxonomy on its own, or fails before
+	 * it has a chance to do so.
+	 */
+	protected function reset_taxonomies() {
+		foreach ( get_taxonomies() as $tax ) {
+			_unregister_taxonomy( $tax );
+		}
+		create_initial_taxonomies();
+	}
+
+	/**
+	 * Unregister non-built-in post statuses.
+	 */
+	protected function reset_post_statuses() {
+		foreach ( get_post_stati( array( '_builtin' => false ) ) as $post_status ) {
+			_unregister_post_status( $post_status );
+		}
+	}
+
+	/**
+	 * Reset `$_SERVER` variables
+	 */
+	protected function reset__SERVER() {
+		tests_reset__SERVER();
+	}
+
+	/**
+	 * Saves the action and filter-related globals so they can be restored later.
+	 *
+	 * Stores $merged_filters, $wp_actions, $wp_current_filter, and $wp_filter
+	 * on a class variable so they can be restored on tearDown() using _restore_hooks().
+	 *
+	 * @global array $merged_filters
+	 * @global array $wp_actions
+	 * @global array $wp_current_filter
+	 * @global array $wp_filter
+	 * @return void
+	 */
+	protected function _backup_hooks() {
+		$globals = array( 'wp_actions', 'wp_current_filter' );
+		foreach ( $globals as $key ) {
+			self::$hooks_saved[ $key ] = $GLOBALS[ $key ];
+		}
+		self::$hooks_saved['wp_filter'] = array();
+		foreach ( $GLOBALS['wp_filter'] as $hook_name => $hook_object ) {
+			self::$hooks_saved['wp_filter'][ $hook_name ] = clone $hook_object;
+		}
+	}
+
+	/**
+	 * Restores the hook-related globals to their state at setUp()
+	 * so that future tests aren't affected by hooks set during this last test.
+	 *
+	 * @global array $merged_filters
+	 * @global array $wp_actions
+	 * @global array $wp_current_filter
+	 * @global array $wp_filter
+	 * @return void
+	 */
+	protected function _restore_hooks() {
+		$globals = array( 'wp_actions', 'wp_current_filter' );
+		foreach ( $globals as $key ) {
+			if ( isset( self::$hooks_saved[ $key ] ) ) {
+				$GLOBALS[ $key ] = self::$hooks_saved[ $key ];
+			}
+		}
+		if ( isset( self::$hooks_saved['wp_filter'] ) ) {
+			$GLOBALS['wp_filter'] = array();
+			foreach ( self::$hooks_saved['wp_filter'] as $hook_name => $hook_object ) {
+				$GLOBALS['wp_filter'][ $hook_name ] = clone $hook_object;
+			}
+		}
+	}
+
+	static function flush_cache() {
+		global $wp_object_cache;
+		$wp_object_cache->group_ops      = array();
+		$wp_object_cache->stats          = array();
+		$wp_object_cache->memcache_debug = array();
+		$wp_object_cache->cache          = array();
+		if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
+			$wp_object_cache->__remoteset();
+		}
+		wp_cache_flush();
+		wp_cache_add_global_groups( array( 'users', 'userlogins', 'usermeta', 'user_meta', 'useremail', 'userslugs', 'site-transient', 'site-options', 'blog-lookup', 'blog-details', 'rss', 'global-posts', 'blog-id-cache', 'networks', 'sites', 'site-details' ) );
+		wp_cache_add_non_persistent_groups( array( 'comment', 'counts', 'plugins' ) );
+	}
+
+	function start_transaction() {
+		global $wpdb;
+		$wpdb->query( 'SET autocommit = 0;' );
+		$wpdb->query( 'START TRANSACTION;' );
+		add_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		add_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+	}
+
+	/**
+	 * Commit the queries in a transaction.
+	 *
+	 * @since 4.1.0
+	 */
+	public static function commit_transaction() {
+		global $wpdb;
+		$wpdb->query( 'COMMIT;' );
+	}
+
+	function _create_temporary_tables( $query ) {
+		if ( 'CREATE TABLE' === substr( trim( $query ), 0, 12 ) ) {
+			return substr_replace( trim( $query ), 'CREATE TEMPORARY TABLE', 0, 12 );
+		}
+		return $query;
+	}
+
+	function _drop_temporary_tables( $query ) {
+		if ( 'DROP TABLE' === substr( trim( $query ), 0, 10 ) ) {
+			return substr_replace( trim( $query ), 'DROP TEMPORARY TABLE', 0, 10 );
+		}
+		return $query;
+	}
+
+	function get_wp_die_handler( $handler ) {
+		return array( $this, 'wp_die_handler' );
+	}
+
+	function wp_die_handler( $message ) {
+		if ( ! is_scalar( $message ) ) {
+			$message = '0';
+		}
+
+		throw new WPDieException( $message );
+	}
+
+	function expectDeprecated() {
+		$annotations = $this->getAnnotations();
+		foreach ( array( 'class', 'method' ) as $depth ) {
+			if ( ! empty( $annotations[ $depth ]['expectedDeprecated'] ) ) {
+				$this->expected_deprecated = array_merge( $this->expected_deprecated, $annotations[ $depth ]['expectedDeprecated'] );
+			}
+			if ( ! empty( $annotations[ $depth ]['expectedIncorrectUsage'] ) ) {
+				$this->expected_doing_it_wrong = array_merge( $this->expected_doing_it_wrong, $annotations[ $depth ]['expectedIncorrectUsage'] );
+			}
+		}
+		add_action( 'deprecated_function_run', array( $this, 'deprecated_function_run' ) );
+		add_action( 'deprecated_argument_run', array( $this, 'deprecated_function_run' ) );
+		add_action( 'deprecated_hook_run', array( $this, 'deprecated_function_run' ) );
+		add_action( 'doing_it_wrong_run', array( $this, 'doing_it_wrong_run' ) );
+		add_action( 'deprecated_function_trigger_error', '__return_false' );
+		add_action( 'deprecated_argument_trigger_error', '__return_false' );
+		add_action( 'deprecated_hook_trigger_error', '__return_false' );
+		add_action( 'doing_it_wrong_trigger_error', '__return_false' );
+	}
+
+	function expectedDeprecated() {
+		$errors = array();
+
+		$not_caught_deprecated = array_diff( $this->expected_deprecated, $this->caught_deprecated );
+		foreach ( $not_caught_deprecated as $not_caught ) {
+			$errors[] = "Failed to assert that $not_caught triggered a deprecated notice";
+		}
+
+		$unexpected_deprecated = array_diff( $this->caught_deprecated, $this->expected_deprecated );
+		foreach ( $unexpected_deprecated as $unexpected ) {
+			$errors[] = "Unexpected deprecated notice for $unexpected";
+		}
+
+		$not_caught_doing_it_wrong = array_diff( $this->expected_doing_it_wrong, $this->caught_doing_it_wrong );
+		foreach ( $not_caught_doing_it_wrong as $not_caught ) {
+			$errors[] = "Failed to assert that $not_caught triggered an incorrect usage notice";
+		}
+
+		$unexpected_doing_it_wrong = array_diff( $this->caught_doing_it_wrong, $this->expected_doing_it_wrong );
+		foreach ( $unexpected_doing_it_wrong as $unexpected ) {
+			$errors[] = "Unexpected incorrect usage notice for $unexpected";
+		}
+
+		// Perform an assertion, but only if there are expected or unexpected deprecated calls or wrongdoings
+		if ( ! empty( $this->expected_deprecated ) ||
+		     ! empty( $this->expected_doing_it_wrong ) ||
+		     ! empty( $this->caught_deprecated ) ||
+		     ! empty( $this->caught_doing_it_wrong ) ) {
+			$this->assertEmpty( $errors, implode( "\n", $errors ) );
+		}
+	}
+
+	/**
+	 * Declare an expected `_deprecated_function()` or `_deprecated_argument()` call from within a test.
+	 *
+	 * @since 4.2.0
+	 *
+	 * @param string $deprecated Name of the function, method, class, or argument that is deprecated. Must match
+	 *                           first parameter of the `_deprecated_function()` or `_deprecated_argument()` call.
+	 */
+	public function setExpectedDeprecated( $deprecated ) {
+		array_push( $this->expected_deprecated, $deprecated );
+	}
+
+	/**
+	 * Declare an expected `_doing_it_wrong()` call from within a test.
+	 *
+	 * @since 4.2.0
+	 *
+	 * @param string $deprecated Name of the function, method, or class that appears in the first argument of the
+	 *                           source `_doing_it_wrong()` call.
+	 */
+	public function setExpectedIncorrectUsage( $doing_it_wrong ) {
+		array_push( $this->expected_doing_it_wrong, $doing_it_wrong );
+	}
+
+	/**
+	 * PHPUnit 6+ compatibility shim.
+	 *
+	 * @param mixed      $exception
+	 * @param string     $message
+	 * @param int|string $code
+	 */
+	public function setExpectedException( $exception, $message = '', $code = null ) {
+		if ( method_exists( 'PHPUnit_Framework_TestCase', 'setExpectedException' ) ) {
+			parent::setExpectedException( $exception, $message, $code );
+		} else {
+			$this->expectException( $exception );
+			if ( '' !== $message ) {
+				$this->expectExceptionMessage( $message );
+			}
+			if ( null !== $code ) {
+				$this->expectExceptionCode( $code );
+			}
+		}
+	}
+
+	function deprecated_function_run( $function ) {
+		if ( ! in_array( $function, $this->caught_deprecated ) ) {
+			$this->caught_deprecated[] = $function;
+		}
+	}
+
+	function doing_it_wrong_run( $function ) {
+		if ( ! in_array( $function, $this->caught_doing_it_wrong ) ) {
+			$this->caught_doing_it_wrong[] = $function;
+		}
+	}
+
+	function assertWPError( $actual, $message = '' ) {
+		$this->assertInstanceOf( 'WP_Error', $actual, $message );
+	}
+
+	function assertNotWPError( $actual, $message = '' ) {
+		if ( is_wp_error( $actual ) && '' === $message ) {
+			$message = $actual->get_error_message();
+		}
+		$this->assertNotInstanceOf( 'WP_Error', $actual, $message );
+	}
+
+	function assertIXRError( $actual, $message = '' ) {
+		$this->assertInstanceOf( 'IXR_Error', $actual, $message );
+	}
+
+	function assertNotIXRError( $actual, $message = '' ) {
+		if ( $actual instanceof IXR_Error && '' === $message ) {
+			$message = $actual->message;
+		}
+		$this->assertNotInstanceOf( 'IXR_Error', $actual, $message );
+	}
+
+	function assertEqualFields( $object, $fields ) {
+		foreach ( $fields as $field_name => $field_value ) {
+			if ( $object->$field_name != $field_value ) {
+				$this->fail();
+			}
+		}
+	}
+
+	function assertDiscardWhitespace( $expected, $actual ) {
+		$this->assertEquals( preg_replace( '/\s*/', '', $expected ), preg_replace( '/\s*/', '', $actual ) );
+	}
+
+	/**
+	 * Asserts that the contents of two un-keyed, single arrays are equal, without accounting for the order of elements.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param array $expected Expected array.
+	 * @param array $actual   Array to check.
+	 */
+	function assertEqualSets( $expected, $actual ) {
+		sort( $expected );
+		sort( $actual );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Asserts that the contents of two keyed, single arrays are equal, without accounting for the order of elements.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param array $expected Expected array.
+	 * @param array $actual   Array to check.
+	 */
+	function assertEqualSetsWithIndex( $expected, $actual ) {
+		ksort( $expected );
+		ksort( $actual );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Asserts that the given variable is a multidimensional array, and that all arrays are non-empty.
+	 *
+	 * @since 4.8.0
+	 *
+	 * @param array $array Array to check.
+	 */
+	function assertNonEmptyMultidimensionalArray( $array ) {
+		$this->assertTrue( is_array( $array ) );
+		$this->assertNotEmpty( $array );
+
+		foreach ( $array as $sub_array ) {
+			$this->assertTrue( is_array( $sub_array ) );
+			$this->assertNotEmpty( $sub_array );
+		}
+	}
+
+	/**
+	 * Sets the global state to as if a given URL has been requested.
+	 *
+	 * This sets:
+	 * - The super globals.
+	 * - The globals.
+	 * - The query variables.
+	 * - The main query.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param string $url The URL for the request.
+	 */
+	function go_to( $url ) {
+		// note: the WP and WP_Query classes like to silently fetch parameters
+		// from all over the place (globals, GET, etc), which makes it tricky
+		// to run them more than once without very carefully clearing everything
+		$_GET = $_POST = array();
+		foreach ( array( 'query_string', 'id', 'postdata', 'authordata', 'day', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages', 'pagenow' ) as $v ) {
+			if ( isset( $GLOBALS[ $v ] ) ) {
+				unset( $GLOBALS[ $v ] );
+			}
+		}
+		$parts = parse_url( $url );
+		if ( isset( $parts['scheme'] ) ) {
+			$req = isset( $parts['path'] ) ? $parts['path'] : '';
+			if ( isset( $parts['query'] ) ) {
+				$req .= '?' . $parts['query'];
+				// parse the url query vars into $_GET
+				parse_str( $parts['query'], $_GET );
+			}
+		} else {
+			$req = $url;
+		}
+		if ( ! isset( $parts['query'] ) ) {
+			$parts['query'] = '';
+		}
+
+		$_SERVER['REQUEST_URI'] = $req;
+		unset( $_SERVER['PATH_INFO'] );
+
+		self::flush_cache();
+		unset( $GLOBALS['wp_query'], $GLOBALS['wp_the_query'] );
+		$GLOBALS['wp_the_query'] = new WP_Query();
+		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
+
+		$public_query_vars  = $GLOBALS['wp']->public_query_vars;
+		$private_query_vars = $GLOBALS['wp']->private_query_vars;
+
+		$GLOBALS['wp']                     = new WP();
+		$GLOBALS['wp']->public_query_vars  = $public_query_vars;
+		$GLOBALS['wp']->private_query_vars = $private_query_vars;
+
+		_cleanup_query_vars();
+
+		$GLOBALS['wp']->main( $parts['query'] );
+	}
+
+	/**
+	 * Allows tests to be skipped on single or multisite installs by using @group annotations.
+	 *
+	 * This is a custom extension of the PHPUnit requirements handling.
+	 *
+	 * Contains legacy code for skipping tests that are associated with an open Trac ticket. Core tests no longer
+	 * support this behaviour.
+	 *
+	 * @since 3.5.0
+	 */
+	protected function checkRequirements() {
+		parent::checkRequirements();
+
+		$annotations = $this->getAnnotations();
+
+		if ( ! empty( $annotations['group'] ) ) {
+			if ( in_array( 'ms-required', $annotations['group'], true ) ) {
+				$this->skipWithoutMultisite();
+			}
+			if ( in_array( 'ms-excluded', $annotations['group'], true ) ) {
+				$this->skipWithMultisite();
+			}
+		}
+
+		// Core tests no longer check against open Trac tickets, but others using WP_UnitTestCase may do so.
+		if ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
+			return;
+		}
+
+		if ( WP_TESTS_FORCE_KNOWN_BUGS ) {
+			return;
+		}
+		$tickets = PHPUnit_Util_Test::getTickets( get_class( $this ), $this->getName( false ) );
+		foreach ( $tickets as $ticket ) {
+			if ( is_numeric( $ticket ) ) {
+				$this->knownWPBug( $ticket );
+			} elseif ( 'Plugin' == substr( $ticket, 0, 6 ) ) {
+				$ticket = substr( $ticket, 6 );
+				if ( $ticket && is_numeric( $ticket ) ) {
+					$this->knownPluginBug( $ticket );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Skips the current test if there is an open Trac ticket associated with it.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param int $ticket_id Ticket number.
+	 */
+	function knownWPBug( $ticket_id ) {
+		if ( WP_TESTS_FORCE_KNOWN_BUGS || in_array( $ticket_id, self::$forced_tickets ) ) {
+			return;
+		}
+		if ( ! TracTickets::isTracTicketClosed( 'https://core.trac.wordpress.org', $ticket_id ) ) {
+			$this->markTestSkipped( sprintf( 'WordPress Ticket #%d is not fixed', $ticket_id ) );
+		}
+	}
+
+	/**
+	 * Skips the current test if there is an open Unit Test Trac ticket associated with it.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @deprecated No longer used since the Unit Test Trac was merged into the Core Trac.
+	 *
+	 * @param int $ticket_id Ticket number.
+	 */
+	function knownUTBug( $ticket_id ) {
+		return;
+	}
+
+	/**
+	 * Skips the current test if there is an open Plugin Trac ticket associated with it.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param int $ticket_id Ticket number.
+	 */
+	function knownPluginBug( $ticket_id ) {
+		if ( WP_TESTS_FORCE_KNOWN_BUGS || in_array( 'Plugin' . $ticket_id, self::$forced_tickets ) ) {
+			return;
+		}
+		if ( ! TracTickets::isTracTicketClosed( 'https://plugins.trac.wordpress.org', $ticket_id ) ) {
+			$this->markTestSkipped( sprintf( 'WordPress Plugin Ticket #%d is not fixed', $ticket_id ) );
+		}
+	}
+
+	/**
+	 * Adds a Trac ticket number to the `$forced_tickets` property.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param int $ticket Ticket number.
+	 */
+	public static function forceTicket( $ticket ) {
+		self::$forced_tickets[] = $ticket;
+	}
+
+	/**
+	 * Custom preparations for the PHPUnit process isolation template.
+	 *
+	 * When restoring global state between tests, PHPUnit defines all the constants that were already defined, and then
+	 * includes included files. This does not work with WordPress, as the included files define the constants.
+	 *
+	 * This method defines the constants after including files.
+	 *
+	 * @param Text_Template $template
+	 */
+	function prepareTemplate( Text_Template $template ) {
+		$template->setVar( array( 'constants' => '' ) );
+		$template->setVar( array( 'wp_constants' => PHPUnit_Util_GlobalState::getConstantsAsString() ) );
+		parent::prepareTemplate( $template );
+	}
+
+	/**
+	 * Creates a unique temporary file name.
+	 *
+	 * The directory in which the file is created depends on the environment configuration.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @return string|bool Path on success, else false.
+	 */
+	function temp_filename() {
+		$tmp_dir = '';
+		$dirs    = array( 'TMP', 'TMPDIR', 'TEMP' );
+		foreach ( $dirs as $dir ) {
+			if ( isset( $_ENV[ $dir ] ) && ! empty( $_ENV[ $dir ] ) ) {
+				$tmp_dir = $dir;
+				break;
+			}
+		}
+		if ( empty( $tmp_dir ) ) {
+			$tmp_dir = '/tmp';
+		}
+		$tmp_dir = realpath( $tmp_dir );
+		return tempnam( $tmp_dir, 'wpunit' );
+	}
+
+	/**
+	 * Checks each of the WP_Query is_* functions/properties against expected boolean value.
+	 *
+	 * Any properties that are listed by name as parameters will be expected to be true; all others are
+	 * expected to be false. For example, assertQueryTrue('is_single', 'is_feed') means is_single()
+	 * and is_feed() must be true and everything else must be false to pass.
+	 *
+	 * @since 2.5.0
+	 * @since 3.8.0 Moved from `Tests_Query_Conditionals` to `WP_UnitTestCase`.
+	 *
+	 * @param string $prop,... Any number of WP_Query properties that are expected to be true for the current request.
+	 */
+	function assertQueryTrue() {
+		global $wp_query;
+		$all  = array(
+			'is_404',
+			'is_admin',
+			'is_archive',
+			'is_attachment',
+			'is_author',
+			'is_category',
+			'is_comment_feed',
+			'is_date',
+			'is_day',
+			'is_embed',
+			'is_feed',
+			'is_front_page',
+			'is_home',
+			'is_month',
+			'is_page',
+			'is_paged',
+			'is_post_type_archive',
+			'is_posts_page',
+			'is_preview',
+			'is_robots',
+			'is_search',
+			'is_single',
+			'is_singular',
+			'is_tag',
+			'is_tax',
+			'is_time',
+			'is_trackback',
+			'is_year',
+		);
+		$true = func_get_args();
+
+		foreach ( $true as $true_thing ) {
+			$this->assertContains( $true_thing, $all, "Unknown conditional: {$true_thing}." );
+		}
+
+		$passed  = true;
+		$message = '';
+
+		foreach ( $all as $query_thing ) {
+			$result = is_callable( $query_thing ) ? call_user_func( $query_thing ) : $wp_query->$query_thing;
+
+			if ( in_array( $query_thing, $true ) ) {
+				if ( ! $result ) {
+					$message .= $query_thing . ' is false but is expected to be true. ' . PHP_EOL;
+					$passed   = false;
+				}
+			} elseif ( $result ) {
+				$message .= $query_thing . ' is true but is expected to be false. ' . PHP_EOL;
+				$passed   = false;
+			}
+		}
+
+		if ( ! $passed ) {
+			$this->fail( $message );
+		}
+	}
+
+	/**
+	 * Selectively deletes a file.
+	 *
+	 * Does not delete a file if its path is set in the `$ignore_files` property.
+	 *
+	 * @param string $file File path.
+	 */
+	function unlink( $file ) {
+		$exists = is_file( $file );
+		if ( $exists && ! in_array( $file, self::$ignore_files ) ) {
+			//error_log( $file );
+			unlink( $file );
+		} elseif ( ! $exists ) {
+			$this->fail( "Trying to delete a file that doesn't exist: $file" );
+		}
+	}
+
+	/**
+	 * Selectively deletes files from a directory.
+	 *
+	 * Does not delete files if their paths are set in the `$ignore_files` property.
+	 *
+	 * @param string $path Directory path.
+	 */
+	function rmdir( $path ) {
+		$files = $this->files_in_dir( $path );
+		foreach ( $files as $file ) {
+			if ( ! in_array( $file, self::$ignore_files ) ) {
+				$this->unlink( $file );
+			}
+		}
+	}
+
+	/**
+	 * Deletes files added to the `uploads` directory during tests.
+	 *
+	 * This method works in tandem with the `setUp()` and `rmdir()` methods:
+	 * - `setUp()` scans the `uploads` directory before every test, and stores its contents inside of the
+	 *   `$ignore_files` property.
+	 * - `rmdir()` and its helper methods only delete files that are not listed in the `$ignore_files` property. If
+	 *   called during `tearDown()` in tests, this will only delete files added during the previously run test.
+	 */
+	function remove_added_uploads() {
+		$uploads = wp_upload_dir();
+		$this->rmdir( $uploads['basedir'] );
+	}
+
+	/**
+	 * Returns a list of all files contained inside a directory.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param string $dir Path to the directory to scan.
+	 *
+	 * @return array List of file paths.
+	 */
+	function files_in_dir( $dir ) {
+		$files = array();
+
+		$iterator = new RecursiveDirectoryIterator( $dir );
+		$objects  = new RecursiveIteratorIterator( $iterator );
+		foreach ( $objects as $name => $object ) {
+			if ( is_file( $name ) ) {
+				$files[] = $name;
+			}
+		}
+
+		return $files;
+	}
+
+	/**
+	 * Returns a list of all files contained inside the `uploads` directory.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @return array List of file paths.
+	 */
+	function scan_user_uploads() {
+		static $files = array();
+		if ( ! empty( $files ) ) {
+			return $files;
+		}
+
+		$uploads = wp_upload_dir();
+		$files   = $this->files_in_dir( $uploads['basedir'] );
+		return $files;
+	}
+
+	/**
+	 * Deletes all directories contained inside a directory.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param string $path Path to the directory to scan.
+	 */
+	function delete_folders( $path ) {
+		$this->matched_dirs = array();
+		if ( ! is_dir( $path ) ) {
+			return;
+		}
+
+		$this->scandir( $path );
+		foreach ( array_reverse( $this->matched_dirs ) as $dir ) {
+			rmdir( $dir );
+		}
+		rmdir( $path );
+	}
+
+	/**
+	 * Retrieves all directories contained inside a directory and stores them in the `$matched_dirs` property. Hidden
+	 * directories are ignored.
+	 *
+	 * This is a helper for the `delete_folders()` method.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param string $dir Path to the directory to scan.
+	 */
+	function scandir( $dir ) {
+		foreach ( scandir( $dir ) as $path ) {
+			if ( 0 !== strpos( $path, '.' ) && is_dir( $dir . '/' . $path ) ) {
+				$this->matched_dirs[] = $dir . '/' . $path;
+				$this->scandir( $dir . '/' . $path );
+			}
+		}
+	}
+
+	/**
+	 * Converts a microtime string into a float.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param string $microtime Time string generated by `microtime()`.
+	 *
+	 * @return float `microtime()` output as a float.
+	 */
+	protected function _microtime_to_float( $microtime ) {
+		$time_array = explode( ' ', $microtime );
+		return array_sum( $time_array );
+	}
+
+	/**
+	 * Deletes a user from the database in a Multisite-agnostic way.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return bool True if the user was deleted.
+	 */
+	public static function delete_user( $user_id ) {
+		if ( is_multisite() ) {
+			return wpmu_delete_user( $user_id );
+		} else {
+			return wp_delete_user( $user_id );
+		}
+	}
+
+	/**
+	 * Resets permalinks and flushes rewrites.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @global WP_Rewrite $wp_rewrite
+	 *
+	 * @param string $structure Optional. Permalink structure to set. Default empty.
+	 */
+	public function set_permalink_structure( $structure = '' ) {
+		global $wp_rewrite;
+
+		$wp_rewrite->init();
+		$wp_rewrite->set_permalink_structure( $structure );
+		$wp_rewrite->flush_rules();
+	}
+
+	/**
+	 * Creates an attachment post from an uploaded file.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @param array $upload         Array of information about the uploaded file, provided by wp_upload_bits().
+	 * @param int   $parent_post_id Optional. Parent post ID.
+	 *
+	 * @return int|WP_Error The attachment ID on success. The value 0 or WP_Error on failure.
+	 */
+	function _make_attachment( $upload, $parent_post_id = 0 ) {
+		$type = '';
+		if ( ! empty( $upload['type'] ) ) {
+			$type = $upload['type'];
+		} else {
+			$mime = wp_check_filetype( $upload['file'] );
+			if ( $mime ) {
+				$type = $mime['type'];
+			}
+		}
+
+		$attachment = array(
+			'post_title'     => basename( $upload['file'] ),
+			'post_content'   => '',
+			'post_type'      => 'attachment',
+			'post_parent'    => $parent_post_id,
+			'post_mime_type' => $type,
+			'guid'           => $upload['url'],
+		);
+
+		$id = wp_insert_attachment( $attachment, $upload['file'], $parent_post_id );
+		wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $upload['file'] ) );
+		return $id;
+	}
+
+	/**
+	 * Updates the modified and modified GMT date of a post in the database.
+	 *
+	 * @since 4.8.0
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $date    Post date, in the format YYYY-MM-DD HH:MM:SS.
+	 *
+	 * @return int|false 1 on success, or false on error.
+	 */
+	protected function update_post_modified( $post_id, $date ) {
+		global $wpdb;
+		return $wpdb->update(
+			$wpdb->posts,
+			array(
+				'post_modified'     => $date,
+				'post_modified_gmt' => $date,
+			),
+			array(
+				'ID' => $post_id,
+			),
+			array(
+				'%s',
+				'%s',
+			),
+			array(
+				'%d',
+			)
+		);
+	}
+}

--- a/tests/phpunit/includes/listener-loader.php
+++ b/tests/phpunit/includes/listener-loader.php
@@ -1,0 +1,7 @@
+<?php
+
+if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner\Version::id(), '7.0', '>=' ) ) {
+	require dirname( __FILE__ ) . '/phpunit7/speed-trap-listener.php';
+} else {
+	require dirname( __FILE__ ) . '/speed-trap-listener.php';
+}

--- a/tests/phpunit/includes/phpunit6-compat.php
+++ b/tests/phpunit/includes/phpunit6-compat.php
@@ -15,10 +15,10 @@ if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner
 	class_alias( 'PHPUnit\Util\GlobalState', 'PHPUnit_Util_GlobalState' );
 	class_alias( 'PHPUnit\Util\Getopt', 'PHPUnit_Util_Getopt' );
 
-	class PHPUnit_Util_Test extends PHPUnit\Util\Test {
+	class PHPUnit_Util_Test {
 
 		public static function getTickets( $className, $methodName ) {
-			$annotations = self::parseTestMethodAnnotations( $className, $methodName );
+			$annotations = PHPUnit\Util\Test::parseTestMethodAnnotations( $className, $methodName );
 
 			$tickets = array();
 

--- a/tests/phpunit/includes/phpunit7/speed-trap-listener.php
+++ b/tests/phpunit/includes/phpunit7/speed-trap-listener.php
@@ -1,0 +1,306 @@
+<?php
+
+/**
+ * A PHPUnit TestListener that exposes your slowest running tests by outputting
+ * results directly to the console.
+ */
+class SpeedTrapListener implements PHPUnit_Framework_TestListener {
+
+	/**
+	 * Internal tracking for test suites.
+	 *
+	 * Increments as more suites are run, then decremented as they finish. All
+	 * suites have been run when returns to 0.
+	 *
+	 * @var integer
+	 */
+	protected $suites = 0;
+
+	/**
+	 * Time in milliseconds at which a test will be considered "slow" and be
+	 * reported by this listener.
+	 *
+	 * @var int
+	 */
+	protected $slowThreshold;
+
+	/**
+	 * Number of tests to report on for slowness.
+	 *
+	 * @var int
+	 */
+	protected $reportLength;
+
+	/**
+	 * Collection of slow tests.
+	 *
+	 * @var array
+	 */
+	protected $slow = array();
+
+	/**
+	 * Construct a new instance.
+	 *
+	 * @param array $options
+	 */
+	public function __construct( array $options = array() ) {
+		$this->loadOptions( $options );
+	}
+
+	/**
+	 * An error occurred.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 * @param Exception              $e
+	 * @param float                   $time
+	 */
+	public function addError( PHPUnit\Framework\Test $test, Throwable $t, float $time ): void {
+	}
+
+	/**
+	 * A warning occurred.
+	 *
+	 * @param PHPUnit_Framework_Test    $test
+	 * @param PHPUnit_Framework_Warning $e
+	 * @param float                     $time
+	 * @since Method available since Release 5.1.0
+	 */
+	public function addWarning( PHPUnit\Framework\Test $test, PHPUnit\Framework\Warning $e, float $time): void {
+	}
+
+	/**
+	 * A failure occurred.
+	 *
+	 * @param PHPUnit_Framework_Test                 $test
+	 * @param PHPUnit_Framework_AssertionFailedError $e
+	 * @param float                                   $time
+	 */
+	public function addFailure( PHPUnit\Framework\Test $test, PHPUnit\Framework\AssertionFailedError $e, float $time): void {
+	}
+
+	/**
+	 * Incomplete test.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 * @param Exception              $e
+	 * @param float                   $time
+	 */
+	public function addIncompleteTest( PHPUnit\Framework\Test $test, Throwable $t, float $time): void {
+	}
+
+	/**
+	 * Risky test.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 * @param Exception              $e
+	 * @param float                   $time
+	 * @since  Method available since Release 4.0.0
+	 */
+	public function addRiskyTest( PHPUnit\Framework\Test $test, Throwable $t, float $time): void {
+	}
+
+	/**
+	 * Skipped test.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 * @param Exception              $e
+	 * @param float                   $time
+	 */
+	public function addSkippedTest( PHPUnit\Framework\Test $test, Throwable $t, float $time): void {
+	}
+
+	/**
+	 * A test started.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 */
+	public function startTest( PHPUnit\Framework\Test $test): void {
+	}
+
+	/**
+	 * A test ended.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 * @param float                   $time
+	 */
+	public function endTest( PHPUnit\Framework\Test $test, float $time): void {
+		if ( ! $test instanceof PHPUnit_Framework_TestCase ) {
+			return;
+		}
+
+		$time      = $this->toMilliseconds( $time );
+		$threshold = $this->getSlowThreshold( $test );
+
+		if ( $this->isSlow( $time, $threshold ) ) {
+			$this->addSlowTest( $test, $time );
+		}
+	}
+
+	/**
+	 * A test suite started.
+	 *
+	 * @param PHPUnit_Framework_TestSuite $suite
+	 */
+	public function startTestSuite( PHPUnit\Framework\TestSuite $suite): void {
+		$this->suites++;
+	}
+
+	/**
+	 * A test suite ended.
+	 *
+	 * @param PHPUnit_Framework_TestSuite $suite
+	 */
+	public function endTestSuite( PHPUnit\Framework\TestSuite $suite): void {
+		$this->suites--;
+
+		if ( 0 === $this->suites && $this->hasSlowTests() ) {
+			arsort( $this->slow ); // Sort longest running tests to the top
+
+			$this->renderHeader();
+			$this->renderBody();
+			$this->renderFooter();
+		}
+	}
+
+	/**
+	 * Whether the given test execution time is considered slow.
+	 *
+	 * @param int $time          Test execution time in milliseconds
+	 * @param int $slowThreshold Test execution time at which a test should be considered slow (milliseconds)
+	 * @return bool
+	 */
+	protected function isSlow( $time, $slowThreshold ) {
+		return $time >= $slowThreshold;
+	}
+
+	/**
+	 * Stores a test as slow.
+	 *
+	 * @param PHPUnit_Framework_TestCase $test
+	 * @param int                         $time Test execution time in milliseconds
+	 */
+	protected function addSlowTest( PHPUnit_Framework_TestCase $test, $time ) {
+		$label = $this->makeLabel( $test );
+
+		$this->slow[ $label ] = $time;
+	}
+
+	/**
+	 * Whether at least one test has been considered slow.
+	 *
+	 * @return bool
+	 */
+	protected function hasSlowTests() {
+		return ! empty( $this->slow );
+	}
+
+	/**
+	 * Convert PHPUnit's reported test time (microseconds) to milliseconds.
+	 *
+	 * @param float $time
+	 * @return int
+	 */
+	protected function toMilliseconds( $time ) {
+		return (int) round( $time * 1000 );
+	}
+
+	/**
+	 * Label for describing a test.
+	 *
+	 * @param PHPUnit_Framework_TestCase $test
+	 * @return string
+	 */
+	protected function makeLabel( PHPUnit_Framework_TestCase $test ) {
+		return sprintf( '%s:%s', get_class( $test ), $test->getName() );
+	}
+
+	/**
+	 * Calculate number of slow tests to report about.
+	 *
+	 * @return int
+	 */
+	protected function getReportLength() {
+		return min( count( $this->slow ), $this->reportLength );
+	}
+
+	/**
+	 * Find how many slow tests occurred that won't be shown due to list length.
+	 *
+	 * @return int Number of hidden slow tests
+	 */
+	protected function getHiddenCount() {
+		$total   = count( $this->slow );
+		$showing = $this->getReportLength( $this->slow );
+
+		$hidden = 0;
+		if ( $total > $showing ) {
+			$hidden = $total - $showing;
+		}
+
+		return $hidden;
+	}
+
+	/**
+	 * Renders slow test report header.
+	 */
+	protected function renderHeader() {
+		echo sprintf( "\n\nYou should really fix these slow tests (>%sms)...\n", $this->slowThreshold );
+	}
+
+	/**
+	 * Renders slow test report body.
+	 */
+	protected function renderBody() {
+		$slowTests = $this->slow;
+
+		$length = $this->getReportLength( $slowTests );
+		for ( $i = 1; $i <= $length; ++$i ) {
+			$label = key( $slowTests );
+			$time  = array_shift( $slowTests );
+
+			echo sprintf( " %s. %sms to run %s\n", $i, $time, $label );
+		}
+	}
+
+	/**
+	 * Renders slow test report footer.
+	 */
+	protected function renderFooter() {
+		if ( $hidden = $this->getHiddenCount( $this->slow ) ) {
+			echo sprintf( '...and there %s %s more above your threshold hidden from view', $hidden == 1 ? 'is' : 'are', $hidden );
+		}
+	}
+
+	/**
+	 * Populate options into class internals.
+	 *
+	 * @param array $options
+	 */
+	protected function loadOptions( array $options ) {
+		$this->slowThreshold = isset( $options['slowThreshold'] ) ? $options['slowThreshold'] : 500;
+		$this->reportLength  = isset( $options['reportLength'] ) ? $options['reportLength'] : 10;
+	}
+
+	/**
+	 * Get slow test threshold for given test. A TestCase can override the
+	 * suite-wide slow threshold by using the annotation @slowThreshold with
+	 * the threshold value in milliseconds.
+	 *
+	 * The following test will only be considered slow when its execution time
+	 * reaches 5000ms (5 seconds):
+	 *
+	 * <code>
+	 *
+	 * @slowThreshold 5000
+	 * public function testLongRunningProcess() {}
+	 * </code>
+	 *
+	 * @param PHPUnit_Framework_TestCase $test
+	 * @return int
+	 */
+	protected function getSlowThreshold( PHPUnit_Framework_TestCase $test ) {
+		$ann = $test->getAnnotations();
+
+		return isset( $ann['method']['slowThreshold'][0] ) ? $ann['method']['slowThreshold'][0] : $this->slowThreshold;
+	}
+}

--- a/tests/phpunit/includes/phpunit7/testcase.php
+++ b/tests/phpunit/includes/phpunit7/testcase.php
@@ -1,7 +1,6 @@
 <?php
 
-require_once dirname( __FILE__ ) . '/abstract-testcase.php';
-
+require_once dirname(dirname( __FILE__ ) ) . '/abstract-testcase.php';
 
 /**
  * Defines a basic fixture to run multiple tests.
@@ -26,7 +25,7 @@ class WP_UnitTestCase extends WP_UnitTestCase_Base {
 	 *
 	 * @throws PHPUnit_Framework_AssertionFailedError
 	 */
-	public static function assertNotFalse( $condition, $message = '' ) {
+	public static function assertNotFalse( $condition, string $message = '' ): void {
 		self::assertThat( $condition, self::logicalNot( self::isFalse() ), $message );
 	}
 }

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -236,7 +236,7 @@ class WP_Canonical_UnitTestCase extends WP_UnitTestCase {
 	public function assertCanonical( $test_url, $expected, $ticket = 0, $expected_doing_it_wrong = array() ) {
 		$this->expected_doing_it_wrong = array_merge( $this->expected_doing_it_wrong, (array) $expected_doing_it_wrong );
 
-		$ticket_ref = ( $ticket > 0 ) ? 'Ticket #' . $ticket : null;
+		$ticket_ref = ( $ticket > 0 ) ? 'Ticket #' . $ticket : '';
 
 		if ( is_string( $expected ) ) {
 			$expected = array( 'url' => $expected );


### PR DESCRIPTION
Testing 43218.2.diff​ from core.trac.wordpress.org/ticket/43218

Updated Travis CI to use PHPUnit 7.x for PHP 7.1, 7.2, and nightly https://github.com/ntwb/wordpress/commit/95d4b04274b0c17e4d9fc1e7f5497b3191068607

See also #14 